### PR TITLE
Add PR template from scRNA-seq_sandbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Purpose:
+What issue(s) does your PR address?
+
+## Results
+If applicable, briefly report your findings.
+
+## Pull Request Check List:
+* [ ] Run a linter
+* [ ] Set the seed (if applicable)
+* [ ] Comments and/or documentation up to date
+* [ ] Double check your paths
+* [ ] Check headline numbering
+* [ ] Spell check any Rmd file or md file
+* [ ] Restart R and run all notebooks fresh and save


### PR DESCRIPTION
So after talking to Kurt and Deepa about this, turns out this won't be invisible online, but when users clone this repo, this won't show up in their Finder windows. Deepa says this should be fine as far as usability goes. 