### PR TITLE
Adding Terms and Conditions File and Statement to Each Module

### DIFF
--- a/compare-processing/README.md
+++ b/compare-processing/README.md
@@ -2,12 +2,12 @@
 
 ## Background and objective
 
-The [refine.bio project](https://github.com/AlexsLemonade/refinebio) is a continuously growing compendium of genome-scale gene expression data from multiple species. 
+The [refine.bio project](https://github.com/AlexsLemonade/refinebio) is a continuously growing compendium of genome-scale gene expression data from multiple species.
 Because it is comprised of many different individual studies and new samples are added to our source repositories all the time, we've selected approaches for data processing/normalization that can be applied to individual samples, rather than whole experiments, where possible.
 We'll perform additional downstream processing steps (e.g., quantile normalization; more on that below) to make samples from different experiments more comparable.
 
 In refine.bio, we prefer to process the _raw data_ using our selected pipelines.
-This is not always possible; sometimes the raw data is unavailable at a source repository or the raw data is in a format that we can not process. 
+This is not always possible; sometimes the raw data is unavailable at a source repository or the raw data is in a format that we can not process.
 In these cases, we use submitter-supplied _processed data_ from the source repositories, but we often need to convert the gene identifiers to the Ensembl gene ids that we use in the rest of our system.
 
 In this small project, we'll explore the same data set ([`GSE39842`](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE39842)) processed three ways:
@@ -16,7 +16,7 @@ In this small project, we'll explore the same data set ([`GSE39842`](https://www
 * **SCANfast-processed data from refine.bio**. We use the `SCANfast` function from the [SCAN.UPC](https://bioconductor.org/packages/release/bioc/html/SCAN.UPC.html) to process Affymetrix array data from raw because it allows us to process individual samples.
 * **Quantile normalized SCANfast-processed data from refine.bio**. We generate a target/reference distribution for each organism using the Affymetrix platform with the largest number of samples for that organism (using the [`preprocessCore`](https://bioconductor.org/packages/release/bioc/html/preprocessCore.html) package) and use that as the target distribution for each sample when delivering the samples a user selects for download.
 
-Ideally, all three processing methods would show similar overall data structures and trends. 
+Ideally, all three processing methods would show similar overall data structures and trends.
 We'll specifically evaluate the following:
 
 * Overall data structure -- what does hierarchical clustering look like?
@@ -70,12 +70,12 @@ To take a high level look at _data structure_, we calculate variance for each ge
 
 We can see that the overall structure looks very similar, with samples grouping first by genotype and then by timepoint in each case.
 
-This, however, does not guarantee that the same genes will be in the clustered matrix in each case. 
+This, however, does not guarantee that the same genes will be in the clustered matrix in each case.
 To explore this, we plotted the overlap between the different processing methods' high variance genes.
 
 ![variance-venn](https://github.com/AlexsLemonade/refinebio-examples/blob/master/compare-processing/plots/high_variance_genes_venn.png)
 
-We can see that the majority of high variance genes are shared between all three methods. 
+We can see that the majority of high variance genes are shared between all three methods.
 The QN list seems to be "more similar" to both the SCANfast and RMA lists than they are to each other.
 
 ### Differential expression analysis
@@ -99,7 +99,7 @@ A number of the genes identified in the original publication (e.g., _jak2a_, _th
 
 We used the differentially expressed genes described above as an "interesting" gene list input into [`WebGestaltR`](https://cran.r-project.org/package=WebGestaltR) for overrepresentation analysis.
 
-The WEB-based GEne SeT AnaLysis Toolkit (WebGestalt) results for each of the processing pipelines, including gene identifier conversions (`User ID Mapping Table` tab) and the enriched gene sets (`Enrichment Results` tab), can be viewed by opening the following HTML files in a web browser: 
+The WEB-based GEne SeT AnaLysis Toolkit (WebGestalt) results for each of the processing pipelines, including gene identifier conversions (`User ID Mapping Table` tab) and the enriched gene sets (`Enrichment Results` tab), can be viewed by opening the following HTML files in a web browser:
 * [`results/pathway_analysis/Project_RMA/Report_RMA.html`](https://github.com/AlexsLemonade/refinebio-examples/blob/master/compare-processing/results/pathway_analysis/Project_RMA/Report_RMA.html)
 * [`results/pathway_analysis/Project_SCANfast/Report_SCANfast.html`](https://github.com/AlexsLemonade/refinebio-examples/blob/master/compare-processing/results/pathway_analysis/Project_SCANfast/Report_SCANfast.html)
 * [`results/pathway_analysis/Project_QN/Report_QN.html`](https://github.com/AlexsLemonade/refinebio-examples/blob/master/compare-processing/results/pathway_analysis/Project_QN/Report_QN.html)
@@ -114,7 +114,9 @@ There are many more pathways identified as significant in the SCANfast-processed
 
 ## Summary
 
-Based on these analyses, our prior experience with these methods, and the [publication that introduced the SCAN methodology](http://doi.org/10.1016/j.ygeno.2012.08.003), SCANfast likely has increased sensitivity over RMA. 
+Based on these analyses, our prior experience with these methods, and the [publication that introduced the SCAN methodology](http://doi.org/10.1016/j.ygeno.2012.08.003), SCANfast likely has increased sensitivity over RMA.
 Because the quantile normalized data is first processed with SCANfast, we would expect these two to show similar patterns and that quantile normalization would "dampen" the biological signal somewhat.
 (In using quantile normalization, we assume that the only differences between samples are of a technical nature and that is certainly not always the case!)
 These analyses are consistent with our expectations.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/compare-processing/data/TERMS_AND_CONDITIONS.md
+++ b/compare-processing/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/differential-expression/README.md
+++ b/differential-expression/README.md
@@ -155,3 +155,5 @@ If you've already created a GCT format file from your data, like is described ab
 [CLSFileCreator](http://software.broadinstitute.org/cancer/software/genepattern/modules/docs/ClsFileCreator/4)
 
 *Now login into [GenePattern](https://cloud.genepattern.org/gp/pages/login.jsf), select a `Differential Expression` module, and follow the instructions to upload and analyze your newly created GCT and CLS files*
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/differential-expression/data/TERMS_AND_CONDITIONS.md
+++ b/differential-expression/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/dimension-reduction/README.md
+++ b/dimension-reduction/README.md
@@ -73,3 +73,5 @@ for your dataset.
 Recommended articles on UMAP:   
 - [How UMAP works with visuals](https://umap-learn.readthedocs.io/en/latest/how_umap_works.html)  
 - [Original paper on UMAP](https://arxiv.org/abs/1802.03426) by McGinnes, Healy & Melville.  
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/dimension-reduction/data/TERMS_AND_CONDITIONS.md
+++ b/dimension-reduction/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/ensembl-id-convert/README.md
+++ b/ensembl-id-convert/README.md
@@ -42,3 +42,5 @@ For the example in this module, the gene expression data and sample metadata are
 If you'd like to adapt an example to include data you've obtained from [refine.bio](https://www.refine.bio/), we recommend placing the files in the `data/` directory and changing the filenames and paths in the notebook to match these files.
 The output of the notebook is a TSV file that contains annotation with gene symbols; this filename should be updated as well.
 We suggest saving the output in the `results/` directory, as this is automatically created by the notebook if moved outside of the GitHub repository structure.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/ensembl-id-convert/data/TERMS_AND_CONDITIONS.md
+++ b/ensembl-id-convert/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/normalize-own-data/README.md
+++ b/normalize-own-data/README.md
@@ -12,14 +12,14 @@ This module requires you to install the following software to run the example yo
 * [**tidyverse**](https://www.tidyverse.org/)
 * **wget** - [installation instructions for Mac with Homebrew](https://www.maketecheasier.com/install-wget-mac/), [installation instructions for Windows 10](https://builtvisible.com/download-your-website-with-wget/) (under _Install WGET in Windows 10_), [installation instructions for Debian or Ubuntu Linux](https://www.cyberciti.biz/faq/how-to-install-wget-togetrid-of-error-bash-wget-command-not-found/)
 
-These requirements can be installed by following the instructions at the links above. 
+These requirements can be installed by following the instructions at the links above.
 The example R Notebooks are designed to check if additional required packages are installed and will install them if they are not.
 
 #### RStudio
 
 We have prepared [a quick guide to RStudio](https://github.com/AlexsLemonade/training-modules/blob/master/intro_to_R_tidyverse/00-rstudio_guide.md) as part of our training content that you may find helpful if you're getting started with RStudio for the first time.
 
-Note that the first time you open RStudio, you should select a CRAN mirror. 
+Note that the first time you open RStudio, you should select a CRAN mirror.
 You can do so by clicking `Tools` > `Global Options` > `Packages` and selecting a CRAN mirror near you with the `Change` button.
 
 You can install the additional R package requirements (e.g., tidyverse) through RStudio.
@@ -52,3 +52,5 @@ In this [example notebook](https://alexslemonade.github.io/refinebio-examples/no
 The R package we use for quantile normalization ([`preprocessCore`](https://bioconductor.org/packages/release/bioc/html/preprocessCore.html)) expects a matrix where samples are columns and genes are rows.
 Any tabular format that can be read into R and follows this format (or can be easily transposed) is appropriate.
 In our example, we use a TSV file where samples are columns and genes are rows.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/normalize-own-data/data/TERMS_AND_CONDITIONS.md
+++ b/normalize-own-data/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/ortholog-mapping/README.md
+++ b/ortholog-mapping/README.md
@@ -1,6 +1,6 @@
 # refine.bio Examples: Ortholog Mapping
 
-[This notebook](https://alexslemonade.github.io/refinebio-examples/ortholog-mapping/ortholog_mapping_example.nb.html) demonstrates how you can use the [`hcop`](https://github.com/stephenturner/hcop) package to perform ortholog mapping for data obtained from refine.bio. 
+[This notebook](https://alexslemonade.github.io/refinebio-examples/ortholog-mapping/ortholog_mapping_example.nb.html) demonstrates how you can use the [`hcop`](https://github.com/stephenturner/hcop) package to perform ortholog mapping for data obtained from refine.bio.
 HCOP stands for HGNC Comparison of Orthology Predictions.
 You can read more about the package [here](https://stephenturner.github.io/hcop).
 
@@ -14,7 +14,7 @@ This module requires you to install the following software to run the example yo
 * [**tidyverse**](https://www.tidyverse.org/)
 * [**devtools**](https://cran.r-project.org/web/packages/devtools/readme/README.html) will be required for installing some packages from GitHub. We recommend installing `devtools` from CRAN.
 
-These requirements can be installed by following the instructions at the links above. 
+These requirements can be installed by following the instructions at the links above.
 The R Notebook is designed to check if additional required packages are installed and will install them if they are not.
 Note that this notebook does check if `devtools` is installed, but we have encountered some trouble with missing system requirements and recommend installing the package prior to running the notebook.
 
@@ -22,7 +22,7 @@ Note that this notebook does check if `devtools` is installed, but we have encou
 
 We have prepared [a quick guide to RStudio](https://github.com/AlexsLemonade/training-modules/blob/master/intro_to_R_tidyverse/00-rstudio_guide.md) as part of our training content that you may find helpful if you're getting started with RStudio for the first time.
 
-Note that the first time you open RStudio, you should select a CRAN mirror. 
+Note that the first time you open RStudio, you should select a CRAN mirror.
 You can do so by clicking `Tools` > `Global Options` > `Packages` and selecting a CRAN mirror near you with the `Change` button.
 
 You can install the additional requirements (e.g., tidyverse) through RStudio.
@@ -45,3 +45,5 @@ For the example in this module, the gene expression data and sample metadata are
 If you'd like to adapt an example to include data you've obtained from [refine.bio](https://www.refine.bio/), we recommend placing the files in the `data/` directory and changing the filenames and paths in the notebook to match these files.
 The output of the notebook is a TSV file that contains annotation with orthologs; this filename should be updated as well.
 We suggest saving the output in the `results/` directory, as this is automatically created by the notebook if moved outside of the GitHub repository structure.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/ortholog-mapping/data/TERMS_AND_CONDITIONS.md
+++ b/ortholog-mapping/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/pathway-analysis/README.md
+++ b/pathway-analysis/README.md
@@ -30,14 +30,14 @@ This module requires you to install the following software to run examples yours
 * [**tidyverse**](https://www.tidyverse.org/)
 * [**devtools**](https://cran.r-project.org/web/packages/devtools/readme/README.html) will be required for installing some packages from GitHub. We recommend installing `devtools` from CRAN.
 
-These requirements can be installed by following the instructions at the links above. 
+These requirements can be installed by following the instructions at the links above.
 The example R Notebooks are designed to check if additional required packages are installed and will install them if they are not.
 
 #### RStudio
 
 We have prepared [a quick guide to RStudio](https://github.com/AlexsLemonade/training-modules/blob/master/intro_to_R_tidyverse/00-rstudio_guide.md) as part of our training content that you may find helpful if you're getting started with RStudio for the first time.
 
-Note that the first time you open RStudio, you should select a CRAN mirror. 
+Note that the first time you open RStudio, you should select a CRAN mirror.
 You can do so by clicking `Tools` > `Global Options` > `Packages` and selecting a CRAN mirror near you with the `Change` button.
 
 You can install the additional requirements (e.g., tidyverse) through RStudio.
@@ -82,13 +82,13 @@ Below, we briefly introduce some commonly used gene set sources.
 QuSAGE, GSEA, and other pathway analysis methods allow you to read in gene sets that are in the [GMT format](http://software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Data_formats#GMT:_Gene_Matrix_Transposed_file_format_.28.2A.gmt.29), a common format for storing gene sets.
 
 The [Molecular Signatures Database (MSigDB)](http://software.broadinstitute.org/gsea/msigdb) offers gene sets in GMT format ([Subramanian et al. _PNAS_. 2005.](https://doi.org/10.1073/pnas.0506580102), [Liberzon et al. _Bioinformatics_. 2011.](https://doi.org/10.1093/bioinformatics/btr260)).
-[Curated gene sets](http://software.broadinstitute.org/gsea/msigdb/collections.jsp#C2) 
-such as [KEGG](https://www.genome.jp/kegg/) ([Kanehisa et al. _NAR_. 2000.](https://doi.org/10.1093/nar/28.1.27), [Kanehisa et al. _NAR_. 2017.](https://doi.org/10.1093/nar/gkw1092), [Kanehisa et al. _NAR_. 2019.](https://doi.org/10.1093/nar/gky962)) are a good starting point for any pathway analysis. 
+[Curated gene sets](http://software.broadinstitute.org/gsea/msigdb/collections.jsp#C2)
+such as [KEGG](https://www.genome.jp/kegg/) ([Kanehisa et al. _NAR_. 2000.](https://doi.org/10.1093/nar/28.1.27), [Kanehisa et al. _NAR_. 2017.](https://doi.org/10.1093/nar/gkw1092), [Kanehisa et al. _NAR_. 2019.](https://doi.org/10.1093/nar/gky962)) are a good starting point for any pathway analysis.
 From the [MSigDB documentation](http://software.broadinstitute.org/gsea/msigdb/collection_details.jsp#C2), curated gene sets are:
 > Gene sets curated from various sources such as online pathway databases, the biomedical literature, and contributions from domain experts.
 
-If you're interested in a smaller set of pathways/gene sets that condense down 
-some of the overlap between gene sets, you might check out the 
+If you're interested in a smaller set of pathways/gene sets that condense down
+some of the overlap between gene sets, you might check out the
 [Hallmark gene set collection](http://software.broadinstitute.org/gsea/msigdb/collection_details.jsp#H) ([Liberzon et al. _Cell Systems_. 2015.](https://doi.org/10.1016/j.cels.2015.12.004)).
 
 Note that the gene sets from MSigDB are for human only.
@@ -120,7 +120,7 @@ In this module, we use Quantitative Set Analysis of Gene Expression (QuSAGE) ([Y
 QuSAGE, implemented in the [`qusage` bioconductor package](https://bioconductor.org/packages/release/bioc/html/qusage.html), has some nice features:
 
 * It takes into account inter-gene correlation (a source of type I error).
-* It returns more information than just a p-value. 
+* It returns more information than just a p-value.
 That's useful for analyses you might want to perform downstream.
 * Built-in visualization functionality.
 
@@ -139,7 +139,7 @@ QuSAGE has been extended to include support for meta-analysis and possesses the 
 
 We have prepared a [**meta-analysis example workflow**](https://alexslemonade.github.io/refinebio-examples/pathway-analysis/qusage_meta_analysis.nb.html) ([Rmd](https://github.com/AlexsLemonade/refinebio-examples/blob/master/pathway-analysis/qusage_meta_analysis.Rmd)) in medulloblastoma.
 
-### GSEA 
+### GSEA
 
 [Gene Set Enrichment Analysis (GSEA)](http://software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Main_Page) is a popular method to determine if gene sets show significant differences between two groups ([Subramanian et al. _PNAS_. 2005.](https://doi.org/10.1073/pnas.0506580102)) and any discussion of pathway analysis would be incomplete without it.
 
@@ -164,7 +164,7 @@ Note that there is also an ssGSEA GenePattern module ([docs](https://gsea-msigdb
 ### Over-representation analysis with WebGestalt
 
 Over-representation analysis (ORA) is a method of pathway or gene set analysis where one can ask if a set of genes (e.g., those differentially expressed using some cutoff) shares more or less genes with gene sets/pathways than we would expect at random.
-The other methodologies introduced throughout this module such as QuSAGE and GSEA can require more samples than a different expression analysis. 
+The other methodologies introduced throughout this module such as QuSAGE and GSEA can require more samples than a different expression analysis.
 For instance, the sample label permutation step of GSEA is reported to perform poorly with 7 samples or less in each group ([Yaari et al. _NAR_. 2013.](https://doi.org/10.1093/nar/gkt660)).
 It is not uncommon to have n = 3 for each group in a treatment-control transcriptomic study, at which point identifying differentially expressed genes is possible.
 If you are performing pathway or gene set analysis on a study of this size, you may be best served by ORA.
@@ -173,3 +173,5 @@ See [Khatri et al. _PLoS Comp Bio._ 2012.](https://doi.org/10.1371/journal.pcbi.
 
 We provide an example workflow for [**performing over-representation analysis with `WebGestaltR`**](https://alexslemonade.github.io/refinebio-examples/pathway-analysis/ora_with_webgestaltr.nb.html) ([Rmd](https://github.com/AlexsLemonade/refinebio-examples/blob/master/pathway-analysis/ora_with_webgestaltr.Rmd)).
 WebGestalt also has a [web interface](http://www.webgestalt.org/) and is not limited to ORA.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/pathway-analysis/data/TERMS_AND_CONDITIONS.md
+++ b/pathway-analysis/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*

--- a/validate-differential-expression/README.md
+++ b/validate-differential-expression/README.md
@@ -88,3 +88,5 @@ This is partially so that this notebook’s approach can be applied to any diffe
 
 Depending on the form of your differential expression results, you will need to alter the steps in [`gene_DE_validate`](https://alexslemonade.github.io/refinebio-examples/validate-differential-expression/gene_DE_validate.nb.html) to obtain the two aforementioned gene lists.
 We advise familiarizing yourself with [`tidyverse`](https://www.tidyverse.org/) functions, particularly the ones used in [this main example](https://alexslemonade.github.io/refinebio-examples/validate-differential-expression/gene_DE_validate.nb.html), to help you determine the how to clean your data for use with this analysis.
+
+\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)

--- a/validate-differential-expression/data/TERMS_AND_CONDITIONS.md
+++ b/validate-differential-expression/data/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,115 @@
+
+# Terms of Use
+
+Welcome to the Alex’s Lemonade Childhood Cancer Data Lab, which is supported by Alex’s Lemonade Stand Foundation ("we," "our," or "us"). These Terms of Use (these "Terms") are a binding legal agreement between you and us regarding your access to and use of the websites located at https://www.ccdatalab.org, https://cognoma.org, http://www.refine.bio or any subdomains thereof and any embedded or associated software, applications, data or other content, provided or managed by us in connection with such websites (collectively, as may be updated, modified or replaced from time to time, the "CCDL").
+
+Please read these Terms carefully. By accessing, registering for, downloading, installing or using the CCDL, or any software, applications, data or other content available on or through the CCDL (collectively, "Content" and any such data, "Data"), you agree to be bound by these Terms and to use the CCDL, including any Content, in accordance with these Terms. If you are using the CCDL on behalf of an entity, you represent and warrant that you have the legal authority to bind such entity to these Terms.
+
+In addition, when using certain features of the CCDL, you also will be subject to the policies, guidelines and terms applicable to such features (collectively, as may be updated from time to time, "Policies"). All Policies, including without limitation the CCDL Privacy Policy, are incorporated by reference into these Terms. If these Terms are inconsistent with any Policy, the terms in the Policy will control to the extent of the inconsistency with respect to the scope of the Policy. You hereby agree to the terms of the CCDL Privacy Policy, located at https://www.ccdatalab.org/privacy-policy.
+
+We may periodically make changes to these Terms, and we will identify the date of last update below. We will post the updated Terms on the CCDL, and we will use commercially reasonable efforts to post changes in advance if we reasonably determine that such changes are material. We may also, in our discretion, use other commercially reasonable methods to attempt to notify you of such changes. Changes to these Terms will be effective upon posting on the CCDL. We encourage you to review the most recent version of these Terms frequently. If you continue to use the CCDL after we modify these Terms, you will be deemed to have consented to the updated Terms as of the date of the modification. If you do not agree to any provision of these Terms, you may not use the CCDL.
+
+## 1. Eligibility    
+Use of the CCDL is void where prohibited. You represent and warrant that any information you submit in connection with the CCDL is accurate, current and complete, that you are 18 years of age or older (or your parent or guardian has reviewed and agreed to these Terms on your behalf), and that you are fully able and competent to enter into and abide by these Terms.
+
+## 2. Account Registration    
+When you register or seek authentication, you must (a) provide accurate, current and complete information, as prompted ("Registration Data"); (b) maintain the security of any logins, passwords, or other credentials that you select or that are provided to you for use on the CCDL; and (c) maintain and promptly update the Registration Data, and any other information you provide to us, and to keep all such information accurate, current and complete. You must notify us as soon as practicable of any unauthorized use of your account or any other breach of security by emailing us at **ccdl@alexslemonade.org**.
+
+## 3. Access to and Use of Content  
+
+### a. Limited License to You.
+Subject to the terms and conditions of these Terms, we hereby grant you a limited, non-transferable, non-sublicensable, revocable license to use the CCDL solely for authorized research or academic purposes in accordance with these Terms.
+
+### b. Use Restrictions.
+In connection with any access to or use of the CCDL (or any Content), you may not:
+
+i. publish, present or otherwise disclose Data, or results from analysis of Data, obtained through the CCDL without properly attributing (i) the Data source using the language provided by the Data contributor of that Data set (as applicable), and (ii) us using the language posted on the CCDL or otherwise provided by us;
+
+ii. use or attempt to use Content to harm, marginalize, or discriminate against individuals or populations;
+
+iii. identify, or make any attempt to identify, any individual to which any Data pertains;
+
+iv. create a false identity, impersonate another individual or entity in any way, or falsely imply that any third-party service is associated with the CCDL;
+
+v. upload or otherwise transmit to or through the CCDL any Content that infringes, misappropriates, or violates any third-party right; that violates, or causes us or our affiliates to violate, any applicable law or regulation; that is unlawful, harmful, harassing, defamatory, threatening, hateful or otherwise objectionable or inappropriate; or that can cause harm or delay to the CCDL (or any connected or related systems) or can expose us or other Users to risk of harm, damage, liability or loss;
+
+vi. upload or otherwise transmit to or through the CCDL any trade secrets or information for which you have any obligation of confidentiality or professional secrecy;
+
+vii. upload or otherwise transmit to or through the CCDL any unsolicited or unauthorized advertising, promotional materials, junk mail, spam, or any other form of solicitation (commercial or otherwise);
+
+viii. distribute, disclose, market, rent, lease or otherwise transfer the CCDL to any other individual or entity;
+
+ix. gain unauthorized access to the CCDL (or any associated Content), to any other User’s account, or to any related or connected systems;
+
+x. post, transmit or otherwise make available any virus, worm, spyware or any other computer code, file or program that may or is intended to damage or hijack the operation of any hardware, software, equipment or systems;
+
+xi. remove, disable, damage, bypass, circumvent or otherwise interfere with any security-related features of the CCDL, except that you may use passwords and other credentials we provide solely as expressly authorized and intended;
+
+xii. interfere with or disrupt the CCDL (or any related or connected systems) or violate the regulations, policies or procedures of any CCDL-related systems;
+
+xiii. violate these Terms or any applicable laws, regulations, standards, principles or guidelines; or
+
+xiv. assist or permit any persons in engaging in any of the activities described above.
+
+You must, immediately upon discovery, report to us any unauthorized access, use, alteration or disclosure of any Content, or other violation of these Terms, including as much detailed information as practicable. We (or our designee) may use any reasonable, lawful tools or methods to monitor use of the CCDL and compliance with these Terms.
+
+## 4. Confidentiality  
+Without limiting any other applicable obligations or restrictions, you will keep strictly confidential (using at least reasonable care), and not disclose or make available to any third party, any information you obtain or access via, regarding or in connection with the CCDL that is marked as confidential or should reasonably be treated as confidential (excluding information specifically identified by us or the source as non-confidential).
+
+## 5. Modifications to the CCDL  
+We reserve the right to modify, discontinue and restrict, temporarily or permanently, all or part of the CCDL (including any Content) without notice in our sole discretion. Neither we nor our licensors, nor any other Users, will be liable to you or to any third party for any modification, discontinuance or restriction of the CCDL or any deletion of any Data or other Content stored on, or otherwise associated with, your account on the CCDL.
+
+## 6. Term and Termination  
+Your account (or other authorized access to the CCDL) remains in effect unless you cancel it or we terminate your access as provided by these Terms. Notwithstanding any other provision of these Terms, we reserve the right, without notice and in our sole discretion, to suspend or terminate your access and to block, restrict and prevent your future access to and use of the CCDL. Without limiting the generality of the foregoing, we may terminate your access in cases of actual or suspected fraud, abuse or violations of these Terms or applicable law, or to protect our organization or any Users from potential harm, disruption, damage, liability or loss. If your access is terminated for any reason, we reserve the right (but do not have the obligation) to delete any Data or other Content associated with your account. Upon any suspension or termination of your access, you must immediately cease using the CCDL. All provisions of these Terms that by their nature should survive (including, without limitation, provisions governing indemnification, limitations of liability, confidentiality, warranty disclaimers, use restrictions, and intellectual property rights) will continue to remain in full force and effect after any termination.
+
+## 7. Feedback  
+Any comments, suggestions, ideas or other information, related to the CCDL, submitted by you to us or the CCDL (collectively, "Feedback") are non-confidential (notwithstanding any notice to the contrary you may include in any accompanying communication), and you hereby grant to us and our affiliates a non-exclusive, royalty-free, perpetual, irrevocable, worldwide, transferable and fully sublicensable right to use your Feedback for any purpose and in any manner without compensation or attribution to you. Where required by applicable law or regulation, we will respect any privacy restrictions applicable to Feedback you communicate to us.
+
+## 8. Copyright Infringement  
+We respect the intellectual property rights of others and ask you to do the same. It is our policy to terminate the access privileges of those who infringe the intellectual property rights of others. If you believe that your work has been posted on the CCDL in a way that constitutes copyright infringement, please contact us at the address below and provide the following information: (a) an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright interest; (b) a description of the copyrighted work that you claim has been infringed, and identification of the time(s) and date(s) the material that you claim is infringing was displayed on the CCDL; (c) your address, telephone number, and email address; (d) a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and (e) a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner’s behalf.
+
+If you believe that your User Content which has been removed (or to which access was disabled) is not infringing, or that you have the authorization from the copyright owner, the copyright owner's agent, or pursuant to applicable law, to post and use such User Content, you may send a counter-notice containing the following information to the copyright agent: (a) your physical or electronic signature; (b) identification of the User Content that has been removed or to which access has been disabled and the location at which the materials appeared before it was removed or disabled; (c) a statement that you have a good faith belief that the User Content was removed or disabled as a result of mistake or a misidentification of the User Content; and (d) your name, address, telephone number, and e-mail address, a statement that, to the extent permitted by applicable law, you consent to the jurisdiction of any federal or state court in the district or state in which you are located (or, if you are located outside of the US, any federal or state court in which we may be found), and a statement that you will accept service of process from the person who provided notification of the alleged infringement. If a counter-notice is received by the copyright agent, we may send a copy of the counter-notice to the original complaining party.
+
+Our designated agent for notice of copyright infringement can be reached at: **ccdl@alexslemonade.org**
+
+## 9. Trademarks  
+ALEX’S LEMONADE STAND®, and any other trademark, logo or other proprietary indicia contained on the CCDL, are trademarks or registered trademarks of ours and our licensors, and may not be copied, imitated or used, in whole or in part, without the prior written permission of the applicable trademark holder. Reference to any products, services, processes or other information, by trade name, trademark, manufacturer, supplier, or otherwise, does not constitute or imply endorsement, sponsorship, or recommendation thereof by us, or vice versa.
+
+## 10. Ownership  
+We, our affiliates and our licensors collectively own all right, title, and interest, including all intellectual property rights, in and to the CCDL. We reserve all rights not expressly granted to you in these Terms.
+
+## 11. Third-Party Content  
+The CCDL may contain links or otherwise provide access to Web pages, services, data or other content of third parties (collectively, "Third-Party Content"). Your access to or use of any Third-Party Content is at your sole risk. We do not monitor, endorse, or adopt, or have any control over, any Third-Party Content. Under no circumstances will we be responsible or liable in any way for or in connection with any Third-Party Content. Third-Party Content may be subject to separate terms and conditions. You should review, and you are solely responsible for complying with, any such third-party terms. You acknowledge and agree that we may use third-party vendors and hosting partners to provide the hardware, software, networking, storage, and related technology used to operate the CCDL.
+
+## 12. Indemnification  
+You will defend, indemnify and hold harmless us, our affiliates, and their respective directors, officers, agents, employees, licensors, and suppliers from and against all claims, losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees and expenses) arising out of or related to your User Content, your use of the CCDL (or any activity under your account or credentials), your violation of these Terms, or your violation of any rights of a third party, except to the extent arising from our gross negligence or willful misconduct.
+
+## 13. Warranty Disclaimers  
+except as expressly set forth in these terms, to the fullest extent permissible under applicable law, (a) we hereby disclaim all warranties related to the ccdl, or any services, data or other content available thereon or associated therewith, including without limitation the implied warranties of merchantability, non-infringement and fitness for a particular purpose; and (b) the ccdl is provided "as is" and without any warranty related to accuracy, completeness, quality or that the ccdl will be uninterrupted or error free.
+we make no representations or warranties regarding, and explicitly disclaim the appropriateness or applicability of any content to, any specific patient’s care or treatment. nor do we make any representations or warranties regarding the use, or the results of the use, of any content in treatment. all content accessible in connection with the ccdl is for informational purposes only. data and other content are not a substitute for professional advice on any matter, medical or otherwise. always seek the advice of a qualified health professional. any clinician is expected to use independent medical judgment in the context of individual clinical circumstances of a specific patient’s care or treatment. we do not recommend or endorse any treatment, institution, professional, physician, product, procedure, or other information that may be mentioned in connection with the ccdl.
+
+## 14. Limitations of Liability  
+to the fullest extent permissible under applicable law, neither us nor our officers, directors, licensors, or suppliers will be liable to any party under these terms or otherwise for any indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with the use or access of or inability to use or access the ccdl or any services or content made available through the ccdl, including without limitation damages for loss of profits, goodwill, use, data or other intangible losses (regardless of the basis of the claim and even if advised of the possibility of these damages).
+to the fullest extent permissible under applicable law, our and our suppliers’ and licensors’ maximum total liability to you for all claims under these terms or otherwise in connection with the ccdl is $50, regardless of the basis of the claim.
+applicable law may not allow the limitation or exclusion of certain warranties or liabilities, so the above limitations or exclusions may not fully apply to you. in such cases, you agree that because such warranty disclaimers and limitations of liability reflect a reasonable and fair allocation of risk between you and us (and are fundamental elements of the basis of the bargain between you and us), our and our licensors’ and suppliers’ liability will be limited to the fullest extent permissible under applicable law. the limitations in this section will apply even if any limited remedy fails of its essential purpose, to the fullest extent permissible under applicable law.
+
+## 15. Electronic Communications    
+By accessing or using the CCDL, you consent to receiving electronic communications from us. You agree that any notices, agreements, disclosures, or other communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.
+
+## 16. Governing Law & Jurisdiction
+
+### a. Governing Law.
+Unless otherwise agreed in writing between you and us, these Terms are governed by and construed in accordance with the laws of the Commonwealth of Pennsylvania, excluding conflicts of law principles.
+
+### b. Jurisdiction.
+Unless otherwise agreed in writing between you and us, any dispute or claim arising out of or relating to the CCDL or these Terms must be brought exclusively in the state or federal courts within the Eastern District of Pennsylvania (except that a party may seek preliminary equitable relief in any court of competent jurisdiction in relation to intellectual property rights or confidentiality obligations).
+
+## 17. General  
+Our failure to act in a particular circumstance does not waive our ability to act with respect to that circumstance or similar circumstances. We will not be responsible or liable for any failure or delay to perform any of our obligations under these Terms resulting from any event or circumstance beyond our reasonable control. Any provision of these Terms that is found to be invalid, unlawful, or unenforceable will be enforced to the fullest extent permissible under applicable law and in all other jurisdictions and circumstances (and otherwise will be severed from these Terms), and the remaining provisions of these Terms will continue to be in full force and effect. The section headings and titles in these Terms are for convenience only and have no legal or contractual effect. You may not assign or delegate any of your rights or obligations under these Terms without our prior written consent, and any purported assignment in contravention of the foregoing will be null and void. These Terms will be binding upon and ensure to the benefit of the parties hereto and their respective successors and permitted assigns. **Any dispute or claim arising out of or relating to the CCDL or these Terms must be commenced within one year after the claim arose.**
+
+These Terms, including all Policies, constitute the entire agreement between you and us concerning the CCDL. These Terms supersede all prior agreements or communications between you and us regarding the subject matter of these Terms.
+
+## 18. Questions & Contact Information  
+If you have any questions or concerns about the CCDL, or these Terms, you may contact us by email at **ccdl@alexslemonade.org.**
+
+*Last Updated: March 2, 2018*


### PR DESCRIPTION
This PR addresses #85 for the rest of the notebooks. After doing a test run with the clustering notebooks in PR #87, I've done the same two changes there for the rest of the modules. If these should be made into individual PRs, let me know. 

Just like with PR #87, exactly two things are changed in each module according to the issue #85 
instructions:

1) `TERMS_AND_CONDITIONS.md` is added to the module's `data` folder. I created the Markdown by copy and pasting from the refine.bio terms page but editing the formatting to be Markdown style.

2) At the very end of the module's README, this is added:
`\* In using these data, you agree to our [terms and conditions](https://www.refine.bio/terms)`

Just to double check, the following modules have had the changes above done:  
- [x] clustering (done in #87)
- [x] compare-processing 
- [x] differential-expression
- [x] dimension-reduction
- [x] ensembl-id-convert
- [x] normalize-own-data
- [x] ortholog-mapping
- [x] pathway-analysis
- [x] validate-differential-expression

You will unfortunately see that there are places where a space is taken away after I saved the Markdown file. This is just a glitch: *No actual text has been changed* (besides the add of the TC statement).