### PR TITLE
Add in more guidance about Docker images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,4 @@ What things should reviewers look out for?
 
 ### Docker/Snakemake
 * [ ] Any not yet added packages needed for this analysis have been added to the Dockerfile and it successfully builds.
-* [ ] In the Docker container, run [snakemake for rendering](https://github.com/AlexsLemonade/refinebio-examples/CONTRIBUTING.md#how-to-re-render-the-notebooks)
+* [ ] In the Docker container, run [snakemake for rendering](https://github.com/AlexsLemonade/refinebio-examples/blob/master/CONTRIBUTING.md#how-to-re-render-the-notebooks)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ What things should reviewers look out for?
 
 ### Content checks
 * [ ] All `{{BLANKS}}` have been replaced with the correct content.
-* [ ] [Sources are cited](https://github.com/AlexsLemonade/refinebio-examples/CONTRIBUTING.md#citing-sources-in-text)
+* [ ] [Sources are cited](https://github.com/AlexsLemonade/refinebio-examples/blob/master/CONTRIBUTING.md#citing-sources-in-text)
 * [ ] Set the seed (if applicable)
 
 ### Formatting Checks

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,11 +7,19 @@ What was your strategy for this new or edited analysis?
 ## Concerns/Questions for reviewers:
 What things should reviewers look out for?
 
-## Pull Request Check List (rougly in order):
+## Analysis Pull Request Check List (roughly in order):
+
+### Content checks
+* [ ] All `{{BLANKS}}` have been replaced with the correct content.
 * [ ] [Sources are cited](https://github.com/AlexsLemonade/refinebio-examples/CONTRIBUTING.md#citing-sources-in-text)
-* [ ] Set the seed (if applicable).
-* [ ] Remove any manual numbering of sections.
-* [ ] Remove any instances of chunk naming.
-* [ ] Spell check any Rmd file or md file.
-* [ ] Comments and documentation are up to date
+* [ ] Set the seed (if applicable)
+
+### Formatting Checks
+* [ ] Removed any manual numbering of sections.
+* [ ] Removed any instances of chunk naming.
+* [ ] Spell checked any Rmd file or md file.
+* [ ] Comments and documentation are up to date.
+
+### Docker/Snakemake
+* [ ] Any not yet added packages needed for this analysis have been added to the Dockerfile and it successfully builds.
 * [ ] In the Docker container, run [snakemake for rendering](https://github.com/AlexsLemonade/refinebio-examples/CONTRIBUTING.md#how-to-re-render-the-notebooks)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ docker push ccdl/refinebio-examples:dev
 ```
 After a few rounds of changes to the Dockerfile has occurred, we can make a new version tag.
 For example, if there is a `ccdl/refinebio-examples:v1` we can move to `v2`.
+So the same steps would be followed above, but you can change where it says `dev` with the appropriate `v` number. 
 
 ### General guidelines for analyses notebooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Now, you can build the docker image locally using:
 ```
 docker build -< Dockerfile -t ccdl/refinebio-examples
 ```
-Or by pulling the image from Docker hub.
+Or by pulling the image from Docker hub (this will by default pull the `latest` version).
 ```
 docker pull ccdl/refinebio-examples
 ```
@@ -70,13 +70,33 @@ The `render-notebooks.R` script adds a `bibliography:` specification in the `.Rm
 Default is the `references.bib` script at the top of the repository.  
 - `--html`: Default is to save the output `.html` file the same name as the input `.Rmd` file. This option allows you to specify an output file name. Default is used by snakemake.
 
-
 ## Adding a new analysis
 
 Copy, paste and rename the `template/template_example.Rmd` file to the new pertinent analysis folder.
 Search for `{{` or `}}` and replace those with the pertinent information.
 Leave comments that are `<!--`and `-->`.
 The introductory info in this template file helps toward our goal of these analyses notebooks being self-contained.
+
+### Docker image management
+
+All necessary packages needed for running the analysis should be added to the `Dockerfile` and it should be re-built to make sure it builds successfully.
+In the `refinebio-examples` repository:
+```
+docker build -< Dockerfile -t ccdl/refinebio-examples
+```
+After a PR with Dockerfile changes is merged, its associated image should be pushed to the Docker hub repository using a `dev` tag.  
+```
+# log in with your credentials
+docker login
+
+# Attach a tag to your docker image
+docker tag ccdl/refinebio-examples ccdl/refinebio-examples:dev
+
+# Push it!
+docker push ccdl/refinebio-examples:dev
+```
+After a few rounds of changes to the Dockerfile has occurred, we can make a new version tag.
+For example, if there is a `ccdl/refinebio-examples:v1` we can move to `v2`.
 
 ### General guidelines for analyses notebooks
 


### PR DESCRIPTION
## Purpose:

Closes #158 

Now that we have the docker image online https://github.com/AlexsLemonade/refinebio-examples/issues/158#issuecomment-673133192 I realized we need more words about how to manage versions of it as well as we need to add that to the PR checklist. 

I'm uncertain how practical/useful my current plan for managing the docker image versions is. 