### PR TITLE
Be consistent about `library(ggplot2)` 

### DIFF
--- a/01-getting-started/getting-started.html
+++ b/01-getting-started/getting-started.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/02-microarray/00-intro-to-microarray.html
+++ b/02-microarray/00-intro-to-microarray.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/02-microarray/clustering_microarray_01_heatmap.html
+++ b/02-microarray/clustering_microarray_01_heatmap.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/02-microarray/dimension-reduction_microarray_01_pca.html
+++ b/02-microarray/dimension-reduction_microarray_01_pca.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/02-microarray/dimension-reduction_microarray_02_umap.html
+++ b/02-microarray/dimension-reduction_microarray_02_umap.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/02-microarray/pathway_analysis_microarray_06_ssgsea.Rmd
+++ b/02-microarray/pathway_analysis_microarray_06_ssgsea.Rmd
@@ -321,24 +321,24 @@ comp_coag_df <- metadata_df %>%
 
 ```{r fig.height=11, fig.width=8.5}
 comp_coag_df %>% 
-  ggplot2::ggplot(ggplot2::aes(x = condition, 
+  ggplot(aes(x = condition, 
                                y = ssgsea_score)) +
-  ggplot2::geom_boxplot() +
-  ggplot2::facet_grid(strain ~ refinebio_specimen_part) +
-  ggplot2::labs(y = "KEGG Complement and Coagulation Cascades") +
-  ggplot2::theme_bw() +
+  geom_boxplot() +
+  facet_grid(strain ~ refinebio_specimen_part) +
+  labs(y = "KEGG Complement and Coagulation Cascades") +
+  theme_bw() +
   # x-axis text at a 45 degree angle to increase readability
-  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1),
-                 text = ggplot2::element_text(size = 15))
+  theme(axis.text.x = element_text(angle = 45, hjust = 1),
+                 text = element_text(size = 15))
 ```
 
 ```{r}
 # saving to file
-ggplot2::ggsave(file.path(plots_dir,
+ggsave(file.path(plots_dir,
                           "GSE75574_ssgsea_comp_coag_facet.pdf" # Replace with relevant output plot name
                           ),
-                plot = ggplot2::last_plot() + 
-                  ggplot2::theme( text = ggplot2::element_text(size = 10)))
+                plot = last_plot() + 
+                  theme( text = element_text(size = 10)))
 ```
 
 Looks like there may be some differences between tissues in this pathway, with
@@ -400,13 +400,13 @@ random_long_df <- as.data.frame(random_ssgsea_results) %>%
 
 # violin plot comparing no. genes / gene set size
 random_long_df %>%
-  ggplot2::ggplot(ggplot2::aes(x = gene_set_size, y = ssgsea_score)) +
-  ggplot2::geom_violin() +
-  ggplot2::coord_flip() +
-  ggplot2::labs(title = "Random gene set scores",
+  ggplot(aes(x = gene_set_size, y = ssgsea_score)) +
+  geom_violin() +
+  coord_flip() +
+  labs(title = "Random gene set scores",
                 x = "gene set size",
                 y = "ssGSEA score") +
-  ggplot2::theme_bw()
+  theme_bw()
 ```
 
 Note how a smaller gene set results in a larger range of scores.

--- a/03-rnaseq/clustering_rnaseq_01_heatmap.html
+++ b/03-rnaseq/clustering_rnaseq_01_heatmap.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/03-rnaseq/dimension-reduction_rnaseq_01_pca.html
+++ b/03-rnaseq/dimension-reduction_rnaseq_01_pca.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
+++ b/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/04-advanced-topics/00-intro-to-advanced-topics.html
+++ b/04-advanced-topics/00-intro-to-advanced-topics.html
@@ -1629,7 +1629,7 @@ div.tocify {
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>

--- a/04-advanced-topics/quantile_normalize_own_data_adv_topics_01.Rmd
+++ b/04-advanced-topics/quantile_normalize_own_data_adv_topics_01.Rmd
@@ -175,10 +175,10 @@ exprs_long_df <- expression_df %>%
 
 ```{r}
 exprs_long_df %>%
-  ggplot2::ggplot(ggplot2::aes(x = value, fill = Sample)) +
-  ggplot2::geom_density(alpha = 0.2) +
-  ggplot2::theme_bw() +
-  ggplot2::labs(title = "Before quantile normalization",
+  ggplot(aes(x = value, fill = Sample)) +
+  geom_density(alpha = 0.2) +
+  theme_bw() +
+  labs(title = "Before quantile normalization",
                 x = "expression value")
 ```
 
@@ -197,10 +197,10 @@ qn_long_df <- qn_df %>%
 
 ```{r}
 qn_p <- qn_long_df %>%
-  ggplot2::ggplot(ggplot2::aes(x = value, fill = Sample)) +
-  ggplot2::geom_density(alpha = 0.2) +
-  ggplot2::theme_bw() +
-  ggplot2::labs(title = "After quantile normalization",
+  ggplot(aes(x = value, fill = Sample)) +
+  geom_density(alpha = 0.2) +
+  theme_bw() +
+  labs(title = "After quantile normalization",
                 x = "expression value")
 qn_p
 ```
@@ -210,10 +210,10 @@ We can use `facet_wrap` to get a better look.
 
 ```{r}
 qn_p +
-  ggplot2::facet_wrap(~ Sample, ncol = 4) +
-  ggplot2::theme(legend.position = "none",
-                 strip.background = ggplot2::element_blank(),
-                 strip.text = ggplot2::element_blank())
+  facet_wrap(~ Sample, ncol = 4) +
+  theme(legend.position = "none",
+                 strip.background = element_blank(),
+                 strip.text = element_blank())
 ```
 
 Quantile normalization was successful.

--- a/04-advanced-topics/validate_differential_expression_adv_topics_00_author_de.Rmd
+++ b/04-advanced-topics/validate_differential_expression_adv_topics_00_author_de.Rmd
@@ -180,10 +180,10 @@ test.probe <- author.df %>%
 # Make a dataframe with the group information
 box.plot <- data.frame(test.probe, subgroup) %>%
 # Use ggplot2 to make a boxplot from this info
-ggplot2::ggplot(., ggplot2::aes(x = subgroup, y = test.probe)) + 
-  ggplot2::geom_boxplot() + 
-  ggplot2::theme_classic() +
-  ggplot2::ggtitle(paste("Probe ID:", stats$affy_probe_ids[32]))
+ggplot(., aes(x = subgroup, y = test.probe)) + 
+  geom_boxplot() + 
+  theme_classic() +
+  ggtitle(paste("Probe ID:", stats$affy_probe_ids[32]))
 
 # Print the plot here
 box.plot

--- a/04-advanced-topics/validate_differential_expression_adv_topics_01.Rmd
+++ b/04-advanced-topics/validate_differential_expression_adv_topics_01.Rmd
@@ -391,10 +391,10 @@ test.gene <- refine.bio.df %>%
 box.plot <- data.frame(test.gene, subgroup = metadata$subgroup) %>%
 
 # Use ggplot2 to make a boxplot from this info
-ggplot2::ggplot(., ggplot2::aes(x = subgroup, y = test.gene)) + 
-  ggplot2::geom_boxplot() + 
-  ggplot2::theme_classic() +
-  ggplot2::ggtitle(paste("refine.bio up gene test:", refine.bio.up.genes[12]))
+ggplot(., aes(x = subgroup, y = test.gene)) + 
+  geom_boxplot() + 
+  theme_classic() +
+  ggtitle(paste("refine.bio up gene test:", refine.bio.up.genes[12]))
 
 # Print the plot here
 box.plot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,8 +199,10 @@ This will help fix some spacing and formatting issues automatically.
 - **Gene names**: When being referenced as a variable name, as in "let's extract the `ENSG0000000123` data", backticks should be used.
 But if the gene is being referred to more as a concept or something that is not specifically referring to code, the backticks can/should be dropped.
 
-- `::` or `library()` - for most packages there is no stipulations on which strategy to use. We like to be able to show both strategies.
-However, for ggplot2, we always use `library(ggplot2)` to avoid the repetition needed for making a plot that could lead to troubleshooting problems for users that may be trying to modify plots. See [issue #211](https://github.com/AlexsLemonade/refinebio-examples/issues/211).
+- `::` or `library()` - for most packages there is no stipulations on which strategy to use.
+We like to be able to show both strategies.
+However, for ggplot2, we always use `library(ggplot2)` to avoid the repetition needed for making a plot that could lead to troubleshooting problems for users that may be trying to modify plots.
+See [issue #211](https://github.com/AlexsLemonade/refinebio-examples/issues/211).
 
 #### No manual section numbering  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,9 @@ This will help fix some spacing and formatting issues automatically.
 - **Gene names**: When being referenced as a variable name, as in "let's extract the `ENSG0000000123` data", backticks should be used.
 But if the gene is being referred to more as a concept or something that is not specifically referring to code, the backticks can/should be dropped.
 
+- `::` or `library()` - for most packages there is no stipulations on which strategy to use. We like to be able to show both strategies.
+However, for ggplot2, we always use `library(ggplot2)` to avoid the repetition needed for making a plot that could lead to troubleshooting problems for users that may be trying to modify plots. See [issue #211](https://github.com/AlexsLemonade/refinebio-examples/issues/211).
+
 #### No manual section numbering  
 
 Numbering will be done automatically in rendering; so no numbers should be put on the sections.

--- a/components/_navbar.html
+++ b/components/_navbar.html
@@ -36,7 +36,7 @@
           <ul class="dropdown-menu">
             <!-- Individual RNA-Seq pages go in this list -->
             <li><a href="../03-rnaseq/00-intro-to-rnaseq.html">Introduction</a></li>
-            <li><a href="../03-rnaseq/clustering-rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
+            <li><a href="../03-rnaseq/clustering_rnaseq_01_heatmap.html">Clustering and Heatmaps</a></li>
             <li><a href="../03-rnaseq/differential-expression_rnaseq_01.html">Differential Expression</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_01_pca.html">Dimension Reduction - PCA</a></li>
             <li><a href="../03-rnaseq/dimension-reduction_rnaseq_02_umap.html">Dimension Reduction - UMAP</a></li>


### PR DESCRIPTION
## Purpose:
Closes #211 

Whether from luck or I didn't realize cbethell and I were already operating on this notion, all the currently updated notebooks do use `library(ggplot2)`. In the project, I searched for `ggplot2::` and only 4 notebooks that are not yet updated. I removed the `ggplot2::`'s anyway, but I also added a bullet point to CONTRIBUTING.md about this being a thing from now on. 

I re-rendered things with snakemake and everything was just fine. 

I also snuck in a link fix in _navbar.html for the clustering rna-seq file which wasn't working. 