### PR TITLE
Create "Hello, world!" GH action to enforce that PR branches are up to date with master

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+


### PR DESCRIPTION
## Purpose

On the OpenPBTA repositories, we require branches are up to date before merging. The way to set that up is to require status checks (CircleCI, AppVeyor, what have you) pass before merging and then you can require branches to be up to date before merging, quoting from the settings here:

> This ensures pull requests targeting a matching branch have been tested with the latest code. This setting will not take effect unless at least one status check is enabled (see below). 

I currently checked the Page Build status, but it never finishes checking so we can never merge a PR without admin powers.

## Strategy

Create GH action that is a one-liner (`echo Hello, world!`) from their simple workflow template. This should almost never fail and should run quickly, which means we do not expect that it will hold up development and we expect it will allow us to require branches be up to date before merging.