### PR TITLE
Add a section about the PR status check to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,3 +339,9 @@ Follow these steps to add the `.html` link to the navigation bar upon rendering.
 6) Replace  `tech-section`, `analysis_file_name` with the corresponding file names.  
 7) Save the file!  
 8) After you [render the notebook with snakemake](#rendering-notebooks), test the link to make sure it works.  
+
+## Pull request status checks
+
+To require that branches are up-to-date with `master` before merging, we need to require that a status check passes before merging to `master`.
+Turning on this setting mitigates the risk that changes that have been merged will be undone by a pull request that was filed first and alters the same file.
+The status check used is a GitHub Action that runs `echo Hello, world!` in a few seconds and does not check that anything can execute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@
     - [Paragraph formatting](#paragraph-formatting)
     - [Citing sources in text](#citing-sources-in-text)
       - [Adding new sources to the `references.bib`](#adding-new-sources-to-the-referencesbib)
+      - [Key naming](#key-naming)
     - [How to spell check](#how-to-spell-check)
 - [Rendering notebooks](#rendering-notebooks)
   - [How to re-render the notebooks](#how-to-re-render-the-notebooks)
@@ -32,6 +33,7 @@
   - [About the render-notebooks.R script](#about-the-render-notebooksr-script)
   - [Add new analyses to the Snakefile](#add-new-analyses-to-the-snakefile)
   - [Add new analyses to the navbar](#add-new-analyses-to-the-navbar)
+- [Pull request status checks](#pull-request-status-checks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
## Purpose

In #221, we added a `echo Hello, world!` to GitHub Actions so we have a status check that allows us to require that pull requests are up to date with `master` before merging but that runs very quickly and should never fail. In 6 months, we might forget that that isn't _really doing anything_ so I wrote something about it in the contributing guidelines.