### PR TITLE
Add action for docker build and Push

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,8 +5,8 @@ name: Build and Push Docker
 on:
   push:
     branches: [ master ]
+    path: docker/Dockerfile
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build-push"
   build-push:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,7 +5,7 @@ name: Build and Push Docker
 on:
   push:
     branches: [ master ]
-    path: docker/Dockerfile
+    paths: [ docker/Dockerfile ]
 
 jobs:
   # This workflow contains a single job called "build-push"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_ID }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       # Build docker image (We are not using caching here to force a clean build)
       - name: Build and Push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,7 +1,7 @@
 name: Build and Push Docker
 
 # Controls when the action will run. Triggers the workflow on push
-# events only for the master branch
+# events only for the master branch, and only when the Dockerfile changes
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,36 @@
+name: Build and Push Docker
+
+# Controls when the action will run. Triggers the workflow on push
+# events only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build-push"
+  build-push:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      # Login to dockerhub
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Build docker image (We are not using caching here to force a clean build)
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: docker
+          file: docker/Dockerfile
+          tags: ccdl/refinebio-examples:latest
+
+
+
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: Build Docker
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 - [Docker for refinebio-examples](#docker-for-refinebio-examples)
   - [Setting up the docker container](#setting-up-the-docker-container)
-  - [Pushing Docker image updates](#pushing-docker-image-updates)
+  - [Docker image updates](#docker-image-updates)
 - [Download the datasets](#download-the-datasets)
 - [Add a new analysis](#add-a-new-analysis)
   - [Setting up a new analysis file](#setting-up-a-new-analysis-file)
@@ -61,7 +61,7 @@ docker run --mount type=bind,target=/home/rstudio,source=$PWD -e PASSWORD=<PASSW
 Now you can navigate to http://localhost:8787/ to start developing.
 Login to the RStudio server with the username `rstudio` and the password you set above.
 
-### Pushing Docker image updates
+### Docker image updates
 
 All necessary packages needed for running all analyses should be added to the `Dockerfile` and it should be re-built to make sure it builds successfully.
 Successful building of the `Dockerfile` will also be checked when the PR is filed by Github Actions.
@@ -70,14 +70,8 @@ In the `refinebio-examples` repository:
 ```
 docker build -< docker/Dockerfile -t ccdl/refinebio-examples
 ```
-After a PR with Dockerfile changes is merged, its associated image should be pushed to the Docker hub repository.
-```
-# log in with your credentials
-docker login
+When a PR with Dockerfile changes is merged, its associated image will be automatically pushed to the Docker hub repository.
 
-# Push it!
-docker push ccdl/refinebio-examples
-```
 
 ## Download the datasets
 
@@ -98,7 +92,6 @@ Click on the links to go to the detailed instructions for each step.
 - Add not yet added packages needed for this analysis to the Dockerfile (make sure it successfully builds).
 - Add the [expected output html file to snakemake](#add-new-analyses-to-the-snakefile)
 - In the Docker container, run [snakemake for rendering](#how-to-re-render-the-notebooks)
-- After PR is merged, [push updated Docker image](#pushing-docker-image-updates).
 
 ### Setting up a new analysis file
 


### PR DESCRIPTION
## Purpose:

If this works, this PR adds an action to automatically build and push the Docker image when a PR is merged to master. 
~~Due to questions about secrets (see below), I have filed this as a draft.~~ Now live!

Closes #236

## Strategy

I added a new workflow that will build the dockerfile and push to dockerhub.

This will not work until we add docker credentials in the github secrets, storing them in ~~`DOCKERHUB_USERNAME`~~ `DOCKER_ID` and ~~`DOCKERHUB_TOKEN`~~ `DOCKER_PASSWORD`. We should talk to the engineering team about whether they have credentials [stored for the organization](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) that we can use, or whether we should have a separate set for this repository. 

## Concerns/Questions for reviewers:

I made this build without using the cache, so that dockerhub builds will be clean and fresh. 
However, this could potentially result in some mismatch between the version that is tested in `docker-build.yml` and the version that ultimately pushed to Dockerhub. I don't expect this to be a problem, as the one in `docker-build.yml` is just a check and is not stored anywhere that anyone else would access it, but I thought it should be mentioned. 

It should be possible to extend this workflow to build the site with a `snakemake` step. The part I don't know is how to get the html files out after the `snakemake` build and committed to the repository. I think it has something to do with artifacts. But this is a problem for later.