### PR TITLE
Remove install2.r from dockerfile and test dockerhub push action

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,6 @@ RUN R -e "BiocManager::install( \
 # Installs packages needed for plottings
 # treemap, interactive plots, and hex plots
 # Rtsne and umap are required for dimension reduction analyses
-# org.Mm.eg.db is required for gene mapping
 RUN Rscript -e  "install.packages( \
     c('ggfortify', \
       'ggsignif', \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,39 +33,50 @@ RUN pip3 install "setuptools==49.3.0" "six==1.15.0" "wheel==0.34.2"
 ###############
 
 # Commonly used R packages
-RUN install2.r --error --deps TRUE \
-    cluster \
-    GGally \
-    optparse \
-    R.utils \
-    RColorBrewer \
-    rprojroot \
-    viridis \
-    styler
+RUN Rscript -e  "install.packages( \
+    c('cluster', \
+      'GGally', \
+      'optparse', \
+      'R.utils', \
+      'RColorBrewer', \
+      'rprojroot', \
+      'viridis', \
+      'styler'))"
+
 
 ##########################
 # Install bioconductor packages
 # org.Mm.eg.db and org.Dr.eg.db are required for gene mapping
-RUN R -e "BiocManager::install(c('affy', 'apeglm', 'Biobase', 'ComplexHeatmap', 'DESeq2', 'EnhancedVolcano', 'limma', 'marray', 'org.Mm.eg.db', 'org.Dr.eg.db'), \
-    update = FALSE)"
+RUN R -e "BiocManager::install( \
+    c('affy', \
+      'apeglm', \
+      'Biobase', \
+      'ComplexHeatmap', \
+      'DESeq2', \
+      'EnhancedVolcano', \
+      'limma', \
+      'marray', \
+      'org.Mm.eg.db', \
+      'org.Dr.eg.db'), \
+     update = FALSE)"
 
 # Installs packages needed for plottings
 # treemap, interactive plots, and hex plots
 # Rtsne and umap are required for dimension reduction analyses
 # org.Mm.eg.db is required for gene mapping
-RUN install2.r --error --deps TRUE \
-    ggfortify \
-    ggsignif \
-    patchwork \
-    pheatmap \
-    Rtsne \
-    umap  \
-    VennDiagram
+RUN Rscript -e  "install.packages( \
+    c('ggfortify', \
+      'ggsignif', \
+      'patchwork', \
+      'pheatmap', \
+      'Rtsne', \
+      'umap', \
+      'VennDiagram'))"
 
 ##########################
 # Install packages from github
 # Need this package to make plots colorblind friendly
-RUN R -e "remotes::install_github('clauswilke/colorblindr', ref = '1ac3d4d62dad047b68bb66c06cee927a4517d678', dependencies = TRUE)"
+RUN Rscript -e "remotes::install_github('clauswilke/colorblindr', ref = '1ac3d4d62dad047b68bb66c06cee927a4517d678', dependencies = TRUE)"
 
 # Install python libraries
 ##########################


### PR DESCRIPTION
## Purpose:
This PR is primarily designed to test #238 (automatic pushing to dockerhub) , but along the way, it closes https://github.com/AlexsLemonade/refinebio-examples/issues/235

## Strategy
I removed calls to `install2.R` and replaced them with the more verbose, but built-in `install.packages()` function. The reasoning here is that this should result in a somewhat smaller docker image, as `install2.R` seems to retain the cached versions of packages, rather than deleting them.

## Concerns/Questions for reviewers:
Did I miss any important packages?
