### PR TITLE
Fix Docker push

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build and Push Docker
 # events only for the master branch, and only when the Dockerfile changes
 on:
   push:
-    branches: [ master ]
+    branches: [ master, jashapiro/docker-push-fix ]
     paths: [ docker/Dockerfile ]
 
 jobs:
@@ -18,10 +18,13 @@ jobs:
       - uses: actions/checkout@v2
       # Login to dockerhub
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_ID }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # set up Docker build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       # Build docker image (We are not using caching here to force a clean build)
       - name: Build and Push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build and Push Docker
 # events only for the master branch, and only when the Dockerfile changes
 on:
   push:
-    branches: [ master, jashapiro/docker-push-fix ]
+    branches: [ master ]
     paths: [ docker/Dockerfile ]
 
 jobs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,6 @@ RUN Rscript -e  "install.packages( \
       'viridis', \
       'styler'))"
 
-
 ##########################
 # Install bioconductor packages
 # org.Mm.eg.db and org.Dr.eg.db are required for gene mapping


### PR DESCRIPTION
This PR is to fix #238, which apparently didn't work quite right. 

It turns out that setting up `buildx` was a required step, so I added it back.

I have confirmed that this workflow now runs and pushes, at least from a branch, so it should from master too.

