### PR TITLE
Fix automatic rendering

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -53,7 +53,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          load: true
           context: docker
           file: docker/Dockerfile
           tags: ccdl/refinebio-examples:latest

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -4,8 +4,6 @@ name: Style and spell check R markdowns
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
I apparently combined two options that I can't combine in docker builds. So now we are just pushing to the registry, which means that later steps are downloaded from dockerhub. Which seems redudnant, but I can't figure out the fix right now. 

I also removed style and spellcheck from pushes to master, since those should be completed when Pull Requests are made.