### PR TITLE
Change inputs for Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -19,14 +19,12 @@ rule target:
 rule render_citations:
     input:
         rmd = "{basedir}/{basename}.Rmd",
-        bib = "references.bib",
-        csl = "components/genetics.csl"
     output:
        "{basedir}/{basename}.html"
     shell:
         "Rscript scripts/render-notebooks.R"
         " --rmd {input.rmd}"
-        " --bib_file {input.bib}"
-        " --cite_style {input.csl}"
+        " --bib_file references.bib"
+        " --cite_style components/genetics.csl"
         " --html {output}"
         " --style"

--- a/Snakefile
+++ b/Snakefile
@@ -20,7 +20,7 @@ rule render_citations:
     input:
         rmd = "{basedir}/{basename}.Rmd",
     output:
-       "{basedir}/{basename}.html"
+        "{basedir}/{basename}.html"
     shell:
         "Rscript scripts/render-notebooks.R"
         " --rmd {input.rmd}"

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,6 @@ rule target:
 rule render_citations:
     input:
         rmd = "{basedir}/{basename}.Rmd",
-        nav = "{basedir}/_navbar.html",
         bib = "references.bib",
         csl = "components/genetics.csl"
     output:


### PR DESCRIPTION
## Purpose:
Now that Snakemake is forced to run everytime before merging to master with GHA (#254), we want to alter when snakemake is run locally. 

Specifically, in the local sense we don't want snakemake to re-run ALL the files  if the _navbar.html, the reference.bib, or .csl file are changed. Those changes will be reflected locally in any Rmd files that are updated but will also be forced to be updated everywhere by GHA befoer merging to master. 

## Strategy
In the Snakefile I delete those three files:  _navbar.html, the reference.bib, or .csl  from the `input` this means snakemake will not evaluate those files when considering if the render script needs to be re-run. It will only look for changes in Rmd files. 

But these files are still provided to the actual script to be run. 