### PR TITLE
Add checking dockerfile for changes to docker-build step

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-        with:
-          # get the full repo
-          fetch-depth: 0
       # Test if Dockerfile has changed
       # sets steps.check_docker.outputs.changed to 1 if the Dockerfile has changed, 0 otherwise
       - name: Check Dockerfile for changes
@@ -27,7 +24,7 @@ jobs:
         env:
           BEFORE: ${{ github.base_ref }}
         run: |
-          git diff-index --name-only $BEFORE > changes.txt
+          git diff-index --name-only origin/$BEFORE > changes.txt
           if grep "docker/Dockerfile" changes.txt ; then
             echo "Dockerfile changed"
             echo "::set-output name=changed::1"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,7 @@ name: Build Docker
 on:
   pull_request:
     branches: [ master ]
+    paths: [ docker/Dockerfile ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -17,23 +18,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      # Test if Dockerfile has changed
-      # sets steps.check_docker.outputs.changed to 1 if the Dockerfile has changed, 0 otherwise
-      - name: Check Dockerfile for changes
-        id: check_docker
-        env:
-          BEFORE: ${{ github.base_ref }}
-        run: |
-          git diff-index --name-only origin/$BEFORE > changes.txt
-          if grep "docker/Dockerfile" changes.txt ; then
-            echo "Dockerfile changed"
-            echo "::set-output name=changed::1"
-          else
-            echo "No change to Dockerfile"
-            echo "::set-output name=changed::0"
-          fi
-          rm changes.txt
-
+      
       # set up Docker build
       - name: Set up Docker Buildx
         if: steps.check_docker.outputs.changed == 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,15 +18,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       # set up Docker build
       - name: Set up Docker Buildx
-        if: steps.check_docker.outputs.changed == 1
         uses: docker/setup-buildx-action@v1
 
       # setup layer cache
       - name: Cache Docker layers
-        if: steps.check_docker.outputs.changed == 1
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
@@ -36,7 +34,6 @@ jobs:
 
       # Build docker image
       - name: Build Docker image
-        if: steps.check_docker.outputs.changed == 1
         uses: docker/build-push-action@v2
         with:
           push: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,11 +17,34 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          # get the full repo
+          fetch-depth: 0
+      # Test if Dockerfile has changed
+      # sets steps.check_docker.outputs.changed to 1 if the Dockerfile has changed, 0 otherwise
+      - name: Check Dockerfile for changes
+        id: check_docker
+        env:
+          BEFORE: ${{ github.base_ref }}
+        run: |
+          git diff-index --name-only $BEFORE > changes.txt
+          if grep "docker/Dockerfile" changes.txt ; then
+            echo "Dockerfile changed"
+            echo "::set-output name=changed::1"
+          else
+            echo "No change to Dockerfile"
+            echo "::set-output name=changed::0"
+          fi
+          rm changes.txt
+
       # set up Docker build
       - name: Set up Docker Buildx
+        if: steps.check_docker.outputs.changed == 1
         uses: docker/setup-buildx-action@v1
+
       # setup layer cache
       - name: Cache Docker layers
+        if: steps.check_docker.outputs.changed == 1
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
@@ -31,6 +54,7 @@ jobs:
 
       # Build docker image
       - name: Build Docker image
+        if: steps.check_docker.outputs.changed == 1
         uses: docker/build-push-action@v2
         with:
           push: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,5 @@ RUN pip3 install \
     "pytz==2020.1" \
     "snakemake==5.20.1"
 
-
 # set final workdir for commands
 WORKDIR /home/rstudio

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,5 +91,6 @@ RUN pip3 install \
     "pytz==2020.1" \
     "snakemake==5.20.1"
 
+
 # set final workdir for commands
 WORKDIR /home/rstudio


### PR DESCRIPTION
Since we are using the `docker-build.yml` step as a check, it would be nice if it ran faster. This PR should accomplish that by making it only run the time consuming docker build steps if the Dockerfile is different from the one in `master`, borrowing ideas from `docker-build-push.yml`