### PR TITLE
Add 'References' header to each example

### DIFF
--- a/02-microarray/clustering_microarray_01_heatmap.Rmd
+++ b/02-microarray/clustering_microarray_01_heatmap.Rmd
@@ -359,3 +359,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/02-microarray/clustering_microarray_01_heatmap.html
+++ b/02-microarray/clustering_microarray_01_heatmap.html
@@ -3325,6 +3325,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Gu2016">
 <p>Gu Z., R. Eils, and M. Schlesner, 2016 Complex heatmaps reveal patterns and correlations in multidimensional genomic data. Bioinformatics.</p>

--- a/02-microarray/differential-expression_microarray_01_2-groups.Rmd
+++ b/02-microarray/differential-expression_microarray_01_2-groups.Rmd
@@ -376,3 +376,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/02-microarray/differential-expression_microarray_01_2-groups.html
+++ b/02-microarray/differential-expression_microarray_01_2-groups.html
@@ -3335,6 +3335,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Blighe2020">
 <p>Blighe K., S. Rana, and M. Lewis, 2020 <em>EnhancedVolcano: Publication-ready volcano plots with enhanced colouring and labeling</em>.</p>

--- a/02-microarray/dimension-reduction_microarray_01_pca.Rmd
+++ b/02-microarray/dimension-reduction_microarray_01_pca.Rmd
@@ -341,3 +341,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/02-microarray/dimension-reduction_microarray_01_pca.html
+++ b/02-microarray/dimension-reduction_microarray_01_pca.html
@@ -3312,6 +3312,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Brems2017">
 <p>Brems M., 2017 A one-stop shop for principal component analysis</p>

--- a/02-microarray/dimension-reduction_microarray_02_umap.Rmd
+++ b/02-microarray/dimension-reduction_microarray_02_umap.Rmd
@@ -338,3 +338,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/02-microarray/dimension-reduction_microarray_02_umap.html
+++ b/02-microarray/dimension-reduction_microarray_02_umap.html
@@ -3308,6 +3308,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Konopka2020">
 <p>Konopka T., 2020 <em>Uniform manifold approximation and projection</em>.</p>

--- a/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
+++ b/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
@@ -352,3 +352,6 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References
+

--- a/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
+++ b/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
@@ -354,4 +354,3 @@ sessioninfo::session_info()
 ```
 
 # References
-

--- a/02-microarray/gene-id-annotation_microarray_01_ensembl.html
+++ b/02-microarray/gene-id-annotation_microarray_01_ensembl.html
@@ -3371,6 +3371,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Carlson2019">
 <p>Carlson M., 2019 Genome wide annotation for mouse</p>

--- a/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd
+++ b/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd
@@ -417,3 +417,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/03-rnaseq/clustering_rnaseq_01_heatmap.html
+++ b/03-rnaseq/clustering_rnaseq_01_heatmap.html
@@ -3448,6 +3448,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Gu2016">
 <p>Gu Z., R. Eils, and M. Schlesner, 2016 Complex heatmaps reveal patterns and correlations in multidimensional genomic data. Bioinformatics.</p>

--- a/03-rnaseq/differential-expression_rnaseq_01.Rmd
+++ b/03-rnaseq/differential-expression_rnaseq_01.Rmd
@@ -469,3 +469,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/03-rnaseq/differential-expression_rnaseq_01.html
+++ b/03-rnaseq/differential-expression_rnaseq_01.html
@@ -3495,6 +3495,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Blighe2020">
 <p>Blighe K., S. Rana, and M. Lewis, 2020 <em>EnhancedVolcano: Publication-ready volcano plots with enhanced colouring and labeling</em>.</p>

--- a/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd
+++ b/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd
@@ -422,3 +422,5 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References

--- a/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
+++ b/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
@@ -3441,6 +3441,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-CCDL2020">
 <p>CCDL, 2020 <em>ScRNA-seq dimension reduction</em>.</p>

--- a/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
+++ b/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
@@ -384,4 +384,3 @@ sessioninfo::session_info()
 ```
 
 # References
-

--- a/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
+++ b/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
@@ -382,3 +382,6 @@ This helps make your code more reproducible by recording what versions of softwa
 # Print session info
 sessioninfo::session_info()
 ```
+
+# References
+

--- a/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.html
+++ b/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.html
@@ -3401,6 +3401,9 @@ sessioninfo::session_info()</code></pre>
 ## 
 ## [1] /usr/local/lib/R/site-library
 ## [2] /usr/local/lib/R/library</code></pre>
+</div>
+<div id="references" class="section level1 unnumbered">
+<h1>References</h1>
 <div id="refs" class="references">
 <div id="ref-Carlson2019-zebrafish">
 <p>Carlson M., 2019 Genome wide annotation for zebrafish</p>


### PR DESCRIPTION
## Purpose:
Closes #275 by adding `References` headers to each example. 

## Strategy
I added `# References` to the end of each current analysis notebook and then re-ran with snakemake. 

## Concerns/Questions for reviewers:
It's interesting that the numbering is left off of the Referrences section? Not sure why this is. Do we not like this? Is this something I should dig into? -- Edit: I looked into this, it seems to be a default for `number_sections: true`. I don't feel like fighting against it particularly. 
