### PR TITLE
Rearrange sentences in getting started sections

### DIFF
--- a/02-microarray/clustering_microarray_01_heatmap.Rmd
+++ b/02-microarray/clustering_microarray_01_heatmap.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/clustering_microarray_01_heatmap.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer.
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders
 

--- a/02-microarray/clustering_microarray_01_heatmap.html
+++ b/02-microarray/clustering_microarray_01_heatmap.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/clustering_microarray_01_heatmap.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/02-microarray/differential-expression_microarray_01_2-groups.Rmd
+++ b/02-microarray/differential-expression_microarray_01_2-groups.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_01_2-groups.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer.
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders
 

--- a/02-microarray/differential-expression_microarray_01_2-groups.html
+++ b/02-microarray/differential-expression_microarray_01_2-groups.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_01_2-groups.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/02-microarray/differential-expression_microarray_02_several-groups.Rmd
+++ b/02-microarray/differential-expression_microarray_02_several-groups.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_02_several-groups.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer.
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders
 

--- a/02-microarray/differential-expression_microarray_02_several-groups.html
+++ b/02-microarray/differential-expression_microarray_02_several-groups.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_02_several-groups.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/02-microarray/dimension-reduction_microarray_01_pca.Rmd
+++ b/02-microarray/dimension-reduction_microarray_01_pca.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/dimension-reduction_microarray_01_pca.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/02-microarray/dimension-reduction_microarray_01_pca.html
+++ b/02-microarray/dimension-reduction_microarray_01_pca.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/dimension-reduction_microarray_01_pca.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/02-microarray/dimension-reduction_microarray_02_umap.Rmd
+++ b/02-microarray/dimension-reduction_microarray_02_umap.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/dimension-reduction_microarray_02_umap.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/02-microarray/dimension-reduction_microarray_02_umap.html
+++ b/02-microarray/dimension-reduction_microarray_02_umap.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/dimension-reduction_microarray_02_umap.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
+++ b/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/02-microarray/gene-id-annotation_microarray_01_ensembl.html
+++ b/02-microarray/gene-id-annotation_microarray_01_ensembl.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/gene-id-annotation_microarray_01_ensembl.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd
+++ b/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd). 
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/03-rnaseq/clustering_rnaseq_01_heatmap.html
+++ b/03-rnaseq/clustering_rnaseq_01_heatmap.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/03-rnaseq/clustering_rnaseq_01_heatmap.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/03-rnaseq/differential-expression_rnaseq_01.Rmd
+++ b/03-rnaseq/differential-expression_rnaseq_01.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/differential_expression_rnaseq_01_rnaseq.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/03-rnaseq/differential-expression_rnaseq_01.html
+++ b/03-rnaseq/differential-expression_rnaseq_01.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/03-rnaseq/differential_expression_rnaseq_01_rnaseq.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/03-rnaseq/dimension-reduction_rnaseq_01_pca.Rmd
+++ b/03-rnaseq/dimension-reduction_rnaseq_01_pca.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_01_pca.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer.
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders
 

--- a/03-rnaseq/dimension-reduction_rnaseq_01_pca.html
+++ b/03-rnaseq/dimension-reduction_rnaseq_01_pca.html
@@ -2554,6 +2554,15 @@ window.onload = function() {
 };
 </script>
 
+<style type="text/css">
+  code{white-space: pre-wrap;}
+  span.smallcaps{font-variant: small-caps;}
+  span.underline{text-decoration: underline;}
+  div.column{display: inline-block; vertical-align: top; width: 50%;}
+  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+  ul.task-list{list-style: none;}
+      </style>
+
 <style type="text/css">code{white-space: pre;}</style>
 <style type="text/css">
   pre:not([class]) {
@@ -2953,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file-of-this-analysis" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file of this analysis</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_01_pca.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>
@@ -3282,7 +3292,7 @@ sessioninfo::session_info()</code></pre>
 ##  collate  en_US.UTF-8                 
 ##  ctype    en_US.UTF-8                 
 ##  tz       Etc/UTC                     
-##  date     2020-10-14                  
+##  date     2020-10-15                  
 ## 
 ## ─ Packages ───────────────────────────────────────────────────────────────────
 ##  package              * version  date       lib source        
@@ -3313,7 +3323,7 @@ sessioninfo::session_info()</code></pre>
 ##  geneplotter            1.66.0   2020-04-27 [1] Bioconductor  
 ##  generics               0.0.2    2018-11-29 [1] RSPM (R 4.0.0)
 ##  GenomeInfoDb         * 1.24.2   2020-06-15 [1] Bioconductor  
-##  GenomeInfoDbData       1.2.3    2020-09-29 [1] Bioconductor  
+##  GenomeInfoDbData       1.2.3    2020-10-06 [1] Bioconductor  
 ##  GenomicRanges        * 1.40.0   2020-04-27 [1] Bioconductor  
 ##  getopt                 1.20.3   2019-03-22 [1] RSPM (R 4.0.0)
 ##  ggplot2              * 3.3.2    2020-06-19 [1] RSPM (R 4.0.1)
@@ -3347,8 +3357,9 @@ sessioninfo::session_info()</code></pre>
 ##  readr                  1.3.1    2018-12-21 [1] RSPM (R 4.0.2)
 ##  rematch2               2.1.2    2020-05-01 [1] RSPM (R 4.0.0)
 ##  rlang                  0.4.7    2020-07-09 [1] RSPM (R 4.0.2)
-##  rmarkdown              2.3      2020-06-18 [1] RSPM (R 4.0.1)
+##  rmarkdown              2.4      2020-09-30 [1] RSPM (R 4.0.2)
 ##  RSQLite                2.2.0    2020-01-07 [1] RSPM (R 4.0.2)
+##  rstudioapi             0.11     2020-02-07 [1] RSPM (R 4.0.0)
 ##  S4Vectors            * 0.26.1   2020-05-16 [1] Bioconductor  
 ##  scales                 1.1.1    2020-05-11 [1] RSPM (R 4.0.0)
 ##  sessioninfo            1.1.1    2018-11-05 [1] RSPM (R 4.0.0)
@@ -3361,7 +3372,7 @@ sessioninfo::session_info()</code></pre>
 ##  tidyselect             1.1.0    2020-05-11 [1] RSPM (R 4.0.0)
 ##  vctrs                  0.3.4    2020-08-29 [1] RSPM (R 4.0.2)
 ##  withr                  2.3.0    2020-09-22 [1] RSPM (R 4.0.2)
-##  xfun                   0.17     2020-09-09 [1] RSPM (R 4.0.2)
+##  xfun                   0.18     2020-09-29 [1] RSPM (R 4.0.2)
 ##  XML                    3.99-0.5 2020-07-23 [1] RSPM (R 4.0.2)
 ##  xtable                 1.8-4    2019-04-21 [1] RSPM (R 4.0.0)
 ##  XVector                0.28.0   2020-04-27 [1] Bioconductor  

--- a/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd
+++ b/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer.
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders
 

--- a/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
+++ b/03-rnaseq/dimension-reduction_rnaseq_02_umap.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file-of-this-analysis" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file of this analysis</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_02_umap.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
+++ b/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.Rmd
@@ -24,9 +24,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/02-microarray/gene-id-convert_microarray_01_ensembl.Rmd).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 

--- a/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.html
+++ b/03-rnaseq/gene-id-annotation_rnaseq_01_ensembl.html
@@ -2962,7 +2962,8 @@ div.tocify {
 <div id="obtain-the-.rmd-file" class="section level2">
 <h2><span class="header-section-number">2.1</span> Obtain the <code>.Rmd</code> file</h2>
 <p>To run this example yourself, <a href="https://alexslemonade.github.io/refinebio-examples/02-microarray/gene-id-convert_microarray_01_ensembl.Rmd">download the <code>.Rmd</code> for this analysis by clicking this link</a>.</p>
-<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.) Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>Clicking this link will most likely send this to your downloads folder on your computer. Move this <code>.Rmd</code> file to where you would like this example and its files to be stored.</p>
+<p>You can open this <code>.Rmd</code> file in RStudio and follow the rest of these steps from there. (See our <a href="https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds">section about getting started with R notebooks</a> if you are unfamiliar with <code>.Rmd</code> files.)</p>
 </div>
 <div id="set-up-your-analysis-folders" class="section level2">
 <h2><span class="header-section-number">2.2</span> Set up your analysis folders</h2>

--- a/template/template_example.Rmd
+++ b/template/template_example.Rmd
@@ -23,9 +23,10 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/ {{RELATIVE PATH TO THIS ANALYSIS FROM REFINEBIO-EXAMPLES}}).
 
-You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.
+
+You can open this `.Rmd` file in RStudio and follow the rest of these steps from there. (See our [section about getting started with R notebooks](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#how-to-get-and-use-rmds) if you are unfamiliar with `.Rmd` files.)
 
 ## Set up your analysis folders 
 


### PR DESCRIPTION
## Purpose:
Closes #270 

Here's the sentence rearrangement that needs to happen from Deepa's comment on that issue: 

> ![Screen Shot 2020-10-05 at 10 23 18 PM](https://user-images.githubusercontent.com/15315514/95151768-859bdc00-0759-11eb-987e-38893810acc3.png)

> `Clicking this link will most likely send this to your downloads folder on your computer.` feels like it is referring to the Getting started with R link instead of the download link. 

> I would move lines 17 and 18, right after line 14.  

## Strategy
I went through each example and the template, brought those two sentences up to the more logical place and then reran snakemake. 

## Concerns/Questions for reviewers:
- Does it look like all examples consistently got this change? 