### PR TITLE
Add a syntax highlight thing

### DIFF
--- a/scripts/render-notebooks.R
+++ b/scripts/render-notebooks.R
@@ -112,7 +112,8 @@ rmarkdown::render(tmp_file,
   output_format = rmarkdown::html_document(
     toc = TRUE, toc_depth = 2,
     toc_float = TRUE, number_sections = TRUE,
-    df_print = "paged"
+    df_print = "paged",
+    highlight = "haddock"
   ),
   # Save to original html output file name
   output_file = output_file


### PR DESCRIPTION
## Purpose:
Closes #287 highlighting code was requested, there's an argument that can do that for us. There's a lot of default themes available, but `haddock` seemed more "highlighty' than the default but not too bold. 

## Strategy
I added `highlight = "haddock"` to the `html_document()` function in `render-notebooks.R` script. 

Here's what that looks like: 
[differential-expression_microarray_01_2-groups.html.zip](https://github.com/AlexsLemonade/refinebio-examples/files/5404214/differential-expression_microarray_01_2-groups.html.zip)


