### PR TITLE
Update github actions to reflect staging branch

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -30,6 +30,7 @@ jobs:
           then
             pages_branch="gh-pages"
           elif [github.ref == 'refs/heads/staging']
+          then
             pages_branch="gh-pages-stages"
           fi
           echo $pages_branch

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo ${GITHUB_REF#refs/*/}
-          if [${GITHUB_REF#refs/*/} == 'refs/heads/master']
+          echo $GITHUB_REF
+          if [ $GITHUB_REF == 'refs/heads/master' ]
           then
             pages_branch="gh-pages"
-          elif [${GITHUB_REF#refs/*/} == 'refs/heads/staging']
+          elif [ $GITHUB_REF == 'refs/heads/staging' ]
           then
             pages_branch="gh-pages-stages"
           fi
@@ -89,7 +89,7 @@ jobs:
 
       # If we are on the staging branch, do not publish to github pages
       - name: Commit changed html back to non-public pages
-        if: ${GITHUB_REF#refs/*/} == 'refs/heads/staging'
+        if: github.ref == 'refs/heads/staging'
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
@@ -97,7 +97,7 @@ jobs:
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public pages
-        if: ${GITHUB_REF#refs/*/} == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           git add -A
           git commit -m 'Render html and publish' || echo "No changes to commit"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,6 +5,8 @@ name: Build, Render, and Push
 on:
   push:
     branches: [ staging, master ]
+  pull_request:
+    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -25,12 +25,14 @@ jobs:
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Checkout pages branch and sync with changes
+        env:
+          merge_branch: github.ref
         run: |
-          echo $github.ref
-          if [$github.ref == 'refs/heads/master']
+          echo $merge_branch
+          if [$merge_branch == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [$github.ref == 'refs/heads/staging']
+          elif [$merge_branch == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -24,23 +24,15 @@ jobs:
           # use alexslemonade-docs-bot
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
-      - name: github.ref
-        run: echo $github.ref
-        
-      - name: If master branch, use public pages branch
-        if: github.ref == 'refs/heads/master'
-        env:
-          pages_branch: gh-pages
-        run: echo $pages_branch
-
-      - name: If staging branch, use non-public pages branch
-        if: github.ref == 'refs/heads/staging'
-        env:
-          pages_branch: gh-pages-stages
-        run: echo $pages_branch
-
       - name: Checkout pages branch and sync with changes
         run: |
+          if [github.ref == 'refs/heads/master']
+          then
+            pages_branch=gh-pages
+          elif [github.ref == 'refs/heads/staging']
+            pages_branch=gh-pages-stages
+          fi 
+          echo $pages_branch
           git config --local user.email "actions@github.com"
           git config --local user.name "Alex's Lemonade Docs Bot"
           git checkout $pages_branch
@@ -95,7 +87,7 @@ jobs:
           snakemake --cores 2 --forceall
 
       # If we are on the staging branch, do not publish to github pages
-      - name: Commit changed html back to staging branch
+      - name: Commit changed html back to non-public pages
         if: github.ref == 'refs/heads/staging'
         run: |
           git add -A
@@ -103,7 +95,7 @@ jobs:
           git push origin gh-pages-stages || echo "No changes to push"
 
       # If we are on the master branch, publish to github pages!
-      - name: Commit changed html to public facing gh-pages
+      - name: Commit changed html to public pages
         if: github.ref == 'refs/heads/master'
         run: |
           git add -A

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -24,6 +24,9 @@ jobs:
           # use alexslemonade-docs-bot
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
+      - name: github.ref
+        run: echo $github.ref
+        
       - name: If master branch, use public pages branch
         if: github.ref == 'refs/heads/master'
         env:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build, Render, and Push
 # events only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build, Render, and Push
 # events only for the master branch
 on:
   push:
-    branches: [ staging, master, cansavvy/gha-updates-pr-process ]
+    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -68,7 +68,7 @@ jobs:
       # download data
       - name: Download data
         run: bash scripts/download-data.sh
-      
+
       - name: Render all pages to html
         run: |
           docker run \
@@ -76,11 +76,18 @@ jobs:
           ccdl/refinebio-examples \
           snakemake --cores 2 --forceall
 
-      - name: Commit changed html
+      # If we are on the staging branch, do not publish to github pages
+      - name: Commit changed html back to staging branch
+        if: github.ref == 'refs/heads/staging'
         run: |
           git add -A
-          git commit -m 'Render html' || echo "No changes to commit"
+          git commit -m 'Render html, do not publish' || echo "No changes to commit"
+          git push origin staging || echo "No changes to push"
+
+      # If we are on the master branch, publish to github pages!
+      - name: Commit changed html to public facing gh-pages
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git add -A
+          git commit -m 'Render html and publish' || echo "No changes to commit"
           git push origin gh-pages || echo "No changes to push"
-
-
-

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           if [github.ref == 'refs/heads/master']
           then
-            pages_branch=gh-pages
+            pages_branch="gh-pages"
           elif [github.ref == 'refs/heads/staging']
-            pages_branch=gh-pages-stages
-          fi 
+            pages_branch="gh-pages-stages"
+          fi
           echo $pages_branch
           git config --local user.email "actions@github.com"
           git config --local user.name "Alex's Lemonade Docs Bot"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo $GITHUB_REF
-          if [ $GITHUB_REF == 'refs/heads/master' ]
+          echo $GITHUB_BASE_REF
+          if [ $GITHUB_BASE_REF == 'refs/heads/master' ]
           then
             pages_branch="gh-pages"
-          elif [ $GITHUB_REF == 'refs/heads/staging' ]
+          elif [ $GITHUB_BASE_REF == 'refs/heads/staging' ]
           then
             pages_branch="gh-pages-stages"
           fi
@@ -89,7 +89,7 @@ jobs:
 
       # If we are on the staging branch, do not publish to github pages
       - name: Commit changed html back to non-public pages
-        if: github.ref == 'refs/heads/staging'
+        if: github.base_ref == 'refs/heads/staging'
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
@@ -97,7 +97,7 @@ jobs:
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public pages
-        if: github.ref == 'refs/heads/master'
+        if: github.base_ref == 'refs/heads/master'
         run: |
           git add -A
           git commit -m 'Render html and publish' || echo "No changes to commit"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -21,11 +21,25 @@ jobs:
           fetch-depth: 0
           # use alexslemonade-docs-bot
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
+
+      - name: If master branch, use public pages branch
+        id: pages_branch
+        if: github.ref == 'refs/heads/master'
+        env:
+          branch: gh-pages
+        run: echo ${{ pages_branch.branch }}
+
+      - name: If staging branch, use non-public pages branch
+        id: pages_branch
+        if: github.ref == 'refs/heads/staging'
+        env:
+          branch: gh-pages-stages
+
       - name: Checkout pages branch and sync with changes
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Alex's Lemonade Docs Bot"
-          git checkout gh-pages
+          git checkout ${{ pages_branch.branch }}
           git merge -s recursive --strategy-option=theirs ${{ github.event.after }}
 
       # Test if Dockerfile has changed

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -25,14 +25,12 @@ jobs:
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Checkout pages branch and sync with changes
-        env:
-          merge_branch: github.ref
         run: |
-          echo $merge_branch
-          if [$merge_branch == 'refs/heads/master']
+          echo ${{ github.ref }}
+          if [${{ github.ref }} == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [$merge_branch == 'refs/heads/staging']
+          elif [${{ github.ref }} == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -23,19 +23,16 @@ jobs:
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
       - name: If master branch, use public pages branch
-        uses: actions/checkout@v2
-        id: pages_branch
         if: github.ref == 'refs/heads/master'
         env:
-          branch: gh-pages
-        run: echo ${{ pages_branch.branch }}
+          pages_branch: gh-pages
+        run: echo ${{ pages_branch }}
 
       - name: If staging branch, use non-public pages branch
-        uses: actions/checkout@v2
-        id: pages_branch
         if: github.ref == 'refs/heads/staging'
         env:
-          branch: gh-pages-stages
+          pages_branch: gh-pages-stages
+        run: echo ${{ pages_branch }}
 
       - name: Checkout pages branch and sync with changes
         run: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo $GITHUB_BASE_REF
-          if [ $GITHUB_BASE_REF == 'refs/heads/master' ]
+          echo $GITHUB_REF
+          if [ $GITHUB_REF == 'refs/heads/master' ]
           then
             pages_branch="gh-pages"
-          elif [ $GITHUB_BASE_REF == 'refs/heads/staging' ]
+          elif [ $GITHUB_REF == 'refs/heads/staging' ]
           then
             pages_branch="gh-pages-stages"
           fi
@@ -89,7 +89,7 @@ jobs:
 
       # If we are on the staging branch, do not publish to github pages
       - name: Commit changed html back to non-public pages
-        if: github.base_ref == 'refs/heads/staging'
+        if: github.ref == 'refs/heads/staging'
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
@@ -97,7 +97,7 @@ jobs:
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public pages
-        if: github.base_ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           git add -A
           git commit -m 'Render html and publish' || echo "No changes to commit"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo ${GITHUB_REF}
-          if [${GITHUB_REF} == 'refs/heads/master']
+          echo ${BRANCH_NAME}
+          if [${BRANCH_NAME} == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [${GITHUB_REF} == 'refs/heads/staging']
+          elif [${BRANCH_NAME} == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi
@@ -89,7 +89,7 @@ jobs:
 
       # If we are on the staging branch, do not publish to github pages
       - name: Commit changed html back to non-public pages
-        if: github.ref == 'refs/heads/staging'
+        if: ${BRANCH_NAME} == 'refs/heads/staging'
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
@@ -97,7 +97,7 @@ jobs:
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public pages
-        if: github.ref == 'refs/heads/master'
+        if: ${BRANCH_NAME} == 'refs/heads/master'
         run: |
           git add -A
           git commit -m 'Render html and publish' || echo "No changes to commit"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -28,19 +28,19 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           pages_branch: gh-pages
-        run: echo ${{ pages_branch }}
+        run: echo $pages_branch
 
       - name: If staging branch, use non-public pages branch
         if: github.ref == 'refs/heads/staging'
         env:
           pages_branch: gh-pages-stages
-        run: echo ${{ pages_branch }}
+        run: echo $pages_branch
 
       - name: Checkout pages branch and sync with changes
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Alex's Lemonade Docs Bot"
-          git checkout ${{ pages_branch.branch }}
+          git checkout $pages_branch
           git merge -s recursive --strategy-option=theirs ${{ github.event.after }}
 
       # Test if Dockerfile has changed

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo ${{ github.ref }}
-          if [${{ github.ref }} == 'refs/heads/master']
+          echo ${GITHUB_REF}
+          if [${GITHUB_REF} == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [${{ github.ref }} == 'refs/heads/staging']
+          elif [${GITHUB_REF} == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build, Render, and Push
 # events only for the master branch
 on:
   push:
-    branches: [ staging, master ]
+    branches: [ staging, master, cansavvy/gha-updates-pr-process ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -23,6 +23,7 @@ jobs:
           token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
 
       - name: If master branch, use public pages branch
+        uses: actions/checkout@v2
         id: pages_branch
         if: github.ref == 'refs/heads/master'
         env:
@@ -30,6 +31,7 @@ jobs:
         run: echo ${{ pages_branch.branch }}
 
       - name: If staging branch, use non-public pages branch
+        uses: actions/checkout@v2
         id: pages_branch
         if: github.ref == 'refs/heads/staging'
         env:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
-          git push origin staging || echo "No changes to push"
+          git push origin gh-pages-stages || echo "No changes to push"
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public facing gh-pages

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          if [github.ref == 'refs/heads/master']
+          echo $github.ref
+          if [$github.ref == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [github.ref == 'refs/heads/staging']
+          elif [$github.ref == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi
-          echo $pages_branch
           git config --local user.email "actions@github.com"
           git config --local user.name "Alex's Lemonade Docs Bot"
           git checkout $pages_branch

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Checkout pages branch and sync with changes
         run: |
-          echo ${BRANCH_NAME}
-          if [${BRANCH_NAME} == 'refs/heads/master']
+          echo ${GITHUB_REF#refs/*/}
+          if [${GITHUB_REF#refs/*/} == 'refs/heads/master']
           then
             pages_branch="gh-pages"
-          elif [${BRANCH_NAME} == 'refs/heads/staging']
+          elif [${GITHUB_REF#refs/*/} == 'refs/heads/staging']
           then
             pages_branch="gh-pages-stages"
           fi
@@ -89,7 +89,7 @@ jobs:
 
       # If we are on the staging branch, do not publish to github pages
       - name: Commit changed html back to non-public pages
-        if: ${BRANCH_NAME} == 'refs/heads/staging'
+        if: ${GITHUB_REF#refs/*/} == 'refs/heads/staging'
         run: |
           git add -A
           git commit -m 'Render html, do not publish' || echo "No changes to commit"
@@ -97,7 +97,7 @@ jobs:
 
       # If we are on the master branch, publish to github pages!
       - name: Commit changed html to public pages
-        if: ${BRANCH_NAME} == 'refs/heads/master'
+        if: ${GITHUB_REF#refs/*/} == 'refs/heads/master'
         run: |
           git add -A
           git commit -m 'Render html and publish' || echo "No changes to commit"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,8 +5,6 @@ name: Build, Render, and Push
 on:
   push:
     branches: [ staging, master ]
-  pull_request:
-    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,10 +1,10 @@
 name: Build Docker
 
-# Controls when the action will run. Triggers the workflow for a pull request for 
+# Controls when the action will run. Triggers the workflow for a pull request for
 # master
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ staging, master ]
     paths: [ docker/Dockerfile ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -5,7 +5,7 @@ name: Style and spell check R markdowns
 # events but only for the master branch
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ staging, master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     zlib1g \
     libbz2-dev \
     liblzma-dev \
-    libreadline-dev
+    libreadline-dev \
+    libglpk40
 
 # libmagick++-dev is needed for coloblindr to install
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     zlib1g \
     libbz2-dev \
     liblzma-dev \
-    libreadline-dev \
-    libglpk40
+    libreadline-dev
 
 # libmagick++-dev is needed for coloblindr to install
 RUN apt-get -y --no-install-recommends install \


### PR DESCRIPTION
## Purpose:
Now that the staging branch is our default, we need github actions to be updated and act accordingly. 

Goal 1: have gha run on staging PRs as it was running for master PRs
Goal 2: make one exception: staging PRs should NOT publish to `gh-pages` which is where the public facing content goes "live".

See this comment: https://github.com/AlexsLemonade/refinebio-examples/issues/297#issuecomment-713002280

## Strategy

1) I added `staging` as an `on:` criteria so that all checks are ran with PRs to `staging` branch. 

2) I tried splitting the commit to gh-pages step into two different `if` `runs` depending on whether it is the `staging` or `master` branch. 

## Concerns/Questions for reviewers:
- Does this look like it should work? I'm particularly unsure about the `if` statements but that's what we'll test here. 
- Is there any facets I missed regarding `staging` that should be addressed? 