### PR TITLE
Docker dep fix: Add lib package 40 thing that clusterprofiler needs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     zlib1g \
     libbz2-dev \
     liblzma-dev \
-    libreadline-dev
+    libreadline-dev \
+    libglpk40
 
 # libmagick++-dev is needed for coloblindr to install
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     zlib1g \
     libbz2-dev \
     liblzma-dev \
-    libreadline-dev \
-    libglpk40
+    libreadline-dev
 
 # libmagick++-dev is needed for coloblindr to install
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN Rscript -e  "install.packages( \
 
 # Install bioconductor packages
 # org.Mm.eg.db and org.Dr.eg.db are required for gene mapping
-RUN R -e "BiocManager::install( \
+RUN R -e "options(warn = 2); BiocManager::install( \
     c('affy', \
       'apeglm', \
       'Biobase', \


### PR DESCRIPTION
## Purpose:
Fix the precipitating event of #312 - clusterprofiler needed a dependency to install even though it docker didn't stop building when it failed to install. 

This was the problem: 
```
#12 608.2 Error in dyn.load(file, DLLpath = DLLpath, ...) : 
#12 608.2   unable to load shared object '/usr/local/lib/R/site-library/igraph/libs/igraph.so':
#12 608.2   libglpk.so.40: cannot open shared object file: No such file or directory
#12 608.2 Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
#12 608.2 Execution halted
#12 608.2 ERROR: lazy loading failed for package ‘enrichplot’
#12 608.2 * removing ‘/usr/local/lib/R/site-library/enrichplot’

ERROR: dependency ‘enrichplot’ is not available for package ‘clusterProfiler’
```

## Strategy
Add back in `libglpk40` which appears to be the thing it needs. 
