### PR TITLE
Stop staging from pushing to dockerhub

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -58,14 +58,14 @@ jobs:
           tags: ccdl/refinebio-examples:latest
       # for staging, we just want to build, but not push
       - name: Build and Load Docker image
-        if: github.ref == 'refs/heads/staging'
+        if: github.ref == 'refs/heads/jashapiro/dont-push-staging-docker'
         uses: docker/build-push-action@v2
         with:
           push: false
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: ccdl/refinebio-examples:latest
+          tags: ccdl/refinebio-examples:staging
       # download data
       - name: Download data
         run: bash scripts/download-data.sh

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -65,7 +65,7 @@ jobs:
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: ccdl/refinebio-examples:staging
+          tags: ccdl/refinebio-examples:latest
       # download data
       - name: Download data
         run: bash scripts/download-data.sh

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -37,40 +37,32 @@ jobs:
           git checkout $pages_branch
           git merge -s recursive --strategy-option=theirs ${{ github.event.after }}
 
-      # Test if Dockerfile has changed
-      # sets steps.check_docker.outputs.changed to 1 if the Dockerfile has changed, 0 otherwise
-      - name: Check Dockerfile for changes
-        id: check_docker
-        env:
-          BEFORE: ${{ github.event.before }}
-        run: |
-          git diff-index --name-only $BEFORE > changes.txt
-          if grep "docker/Dockerfile" changes.txt ; then
-            echo "Dockerfile changed"
-            echo "::set-output name=changed::1"
-          else
-            echo "No change to Dockerfile"
-            echo "::set-output name=changed::0"
-          fi
-          rm changes.txt
-
       # Login to Dockerhub
       - name: Login to DockerHub
-        if: steps.check_docker.outputs.changed == 1
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_ID }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       # set up Docker build
       - name: Set up Docker Buildx
-        if: steps.check_docker.outputs.changed == 1
         uses: docker/setup-buildx-action@v1
-      # Build docker image (We are not using caching here to force a clean build)
+
+      # Build docker image and push if this is master
       - name: Build and Push Docker image
-        if: steps.check_docker.outputs.changed == 1
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v2
         with:
           push: true
+          context: docker
+          file: docker/Dockerfile
+          tags: ccdl/refinebio-examples:latest
+      # for staging, we just want to build, but not push
+      - name: Build and Load Docker image
+        if: github.ref == 'refs/heads/staging'
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
           context: docker
           file: docker/Dockerfile
           tags: ccdl/refinebio-examples:latest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -46,19 +46,8 @@ jobs:
       # set up Docker build
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      # Build docker image and push if this is master
-      - name: Build and Push Docker image
-        if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: docker
-          file: docker/Dockerfile
-          tags: ccdl/refinebio-examples:latest
-      # for staging, we just want to build, but not push
+      # Build the Docker image
       - name: Build and Load Docker image
-        if: github.ref == 'refs/heads/jashapiro/dont-push-staging-docker'
         uses: docker/build-push-action@v2
         with:
           push: false
@@ -66,10 +55,14 @@ jobs:
           context: docker
           file: docker/Dockerfile
           tags: ccdl/refinebio-examples:latest
+      # push the Docker image if this is master
+      - name: Push Docker image
+        if: github.ref == 'refs/heads/master'
+        run: docker push ccdl/refinebio-examples:latest
+      
       # download data
       - name: Download data
         run: bash scripts/download-data.sh
-
       - name: Render all pages to html
         run: |
           docker run \

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -54,13 +54,11 @@ jobs:
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: |
-            ccdl/refinebio-examples:latest
-            ccdl/refinebio-examples:test
+          tags: ccdl/refinebio-examples:latest
       # push the Docker image if this is master
       - name: Push Docker image
-        if: github.ref == 'refs/heads/jashapiro/dont-push-staging-docker'
-        run: docker push ccdl/refinebio-examples:test
+        if: github.ref == 'refs/heads/master'
+        run: docker push ccdl/refinebio-examples:latest
       
       # download data
       - name: Download data

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build, Render, and Push
 # events only for the master branch
 on:
   push:
-    branches: [ staging, master ]
+    branches: [ staging, master, jashapiro/dont-push-staging-docker ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -54,11 +54,13 @@ jobs:
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: ccdl/refinebio-examples:latest
+          tags: |
+            ccdl/refinebio-examples:latest
+            ccdl/refinebio-examples:test
       # push the Docker image if this is master
       - name: Push Docker image
-        if: github.ref == 'refs/heads/master'
-        run: docker push ccdl/refinebio-examples:latest
+        if: github.ref == 'refs/heads/jashapiro/dont-push-staging-docker'
+        run: docker push ccdl/refinebio-examples:test
       
       # download data
       - name: Download data

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -55,10 +55,16 @@ jobs:
           context: docker
           file: docker/Dockerfile
           tags: ccdl/refinebio-examples:latest
-      # push the Docker image if this is master
+      # push the Docker image if this is staging
       - name: Push Docker image
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/staging'
         run: docker push ccdl/refinebio-examples:latest
+      # retag and push the Docker image if this is master
+      - name: Push release Docker image
+        if: github.ref == 'refs/heads/master'
+        run: | 
+          docker tag ccdl/refinebio-examples:latest ccdl/refinebio-examples:release
+          docker push ccdl/refinebio-examples:release
       
       # download data
       - name: Download data

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Build, Render, and Push
 # events only for the master branch
 on:
   push:
-    branches: [ staging, master, jashapiro/dont-push-staging-docker ]
+    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"


### PR DESCRIPTION
## Purpose:
Addresses some considerations related to #297  arising from unexpected consequences of #311 
Namely, that we don't really want to overwrite the docker image on Dockerhub that is tagged as `latest` to be something from staging.

## Strategy

I abandoned my fancy "did it change" code, so we build the docker image every time. This is mostly because I was worried about a change somehow hiding and resulting in not building the required image. (The case I can envision is two merges in rapid succession, the first has changes in the Dockerfile, the second doesn't (relative to the first), so it skips the build step and then ends up pulling the "old" image from Dockerhub)

The costs of using the wrong build seem higher than the cost of building more often than is strictly necessary.

Following that, I change the build step from "Build and Push" to "Build and Load".

Then in a separate step we push to Dockerhub if we are in the `master` branch. 

## Concerns/Questions for reviewers:

We could push a `staging` tagged docker image to Dockerhub, but I have elected not to do that; if there is a reason we might want to, I would consider it.

Note, in the current setup, the push step will be skipped until this is merged to master, but I have [tested it](https://github.com/AlexsLemonade/refinebio-examples/runs/1289291981?check_suite_focus=true) with a different tag.

