### PR TITLE
Try a "main PR" strategy with links to the real PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,13 @@
 ### Use a link to choose a PR template meant for the type of changes you are proposing:
 
 For any stage of a adding a new analysis example:
-[New analysis PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=new-analysis-pr.md).
+New analysis PR - `?expand=1&template=new-analysis-pr.md`
 
 For publishing changes to Github pages:
-[Publishing PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=publish-pr.md).
+Publishing PR - `?expand=1&template=publish-pr.md`
 
 For either stage of a hotfix PR -- something that is straightforward and needs to be user-facing quickly:
-[Hotfix PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=hotfix-pr.md).
+Hotfix PR - `?expand=1&template=hotfix-pr.md`
 
 For any other types of PRs that don't fit any of the above:
-[Other PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=other-pr.md).
+Other PR - `?expand=1&template=other-pr.md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+
+
+### Click on a link to choose a PR template that should suite your needs:
+
+For publishing changes to Github pages:
+[Publishing PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=publish-pr.md).
+
+For any stage of a adding a new analysis example:
+[New analysis PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=new-analysis-pr.md).
+
+For either stage of a hotfix PR -- something that is straightforward and needs to be user-facing quickly:
+[Hotfix PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=hotfix-pr.md).
+
+For any other types of PRs that don't fit any of the above:
+[Other PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=other-pr.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 
 ### Use a link to choose a PR template meant for the type of changes you are proposing:
 
-For any stage of a adding a new analysis example:
+For any stage of adding a new analysis example:
 <a href="?expand=1&template=new-analysis-pr.md"> New analysis PR </a>
 
 For publishing changes to Github pages:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,11 @@
 
-
-### Click on a link to choose a PR template that should suite your needs:
-
-For publishing changes to Github pages:
-[Publishing PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=publish-pr.md).
+### Use a link to choose a PR template meant for the type of changes you are proposing:
 
 For any stage of a adding a new analysis example:
 [New analysis PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=new-analysis-pr.md).
+
+For publishing changes to Github pages:
+[Publishing PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=publish-pr.md).
 
 For either stage of a hotfix PR -- something that is straightforward and needs to be user-facing quickly:
 [Hotfix PR](https://github.com/AlexsLemonade/refinebio-examples/compare/survey?expand=1&template=hotfix-pr.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,13 @@
 ### Use a link to choose a PR template meant for the type of changes you are proposing:
 
 For any stage of a adding a new analysis example:
-New analysis PR - `?expand=1&template=new-analysis-pr.md`
+<a href="?expand=1&template=new-analysis-pr.md"> New analysis PR </a>
 
 For publishing changes to Github pages:
-Publishing PR - `?expand=1&template=publish-pr.md`
+<a href="?expand=1&template=publish-pr.md"> Publishing PR </a>
 
 For either stage of a hotfix PR -- something that is straightforward and needs to be user-facing quickly:
-Hotfix PR - `?expand=1&template=hotfix-pr.md`
+<a href="?expand=1&template=hotfix-pr.md"> Hotfix PR </a>
 
 For any other types of PRs that don't fit any of the above:
-Other PR - `?expand=1&template=other-pr.md`
+<a href="?expand=1&template=other-pr.md"> Other PR </a>

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-pr.md
@@ -1,12 +1,3 @@
----
-name: Hotfix PR
-about: Use this PR template for filing a a hotfix directly to master (and then also to staging)
-title: 'Hotfix:'
-labels: hotfix
-assignees: ''
-
----
-
 ## Hotfix Purpose
 
 <!-- What is the urgent and straightforward problem that requires hotfix; why is a hotfix needed? -->

--- a/.github/PULL_REQUEST_TEMPLATE/new-analysis-pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-analysis-pr.md
@@ -1,12 +1,3 @@
----
-name: New analysis PR
-about: Use this PR template for filing a new analysis issue
-title: 'New Analysis'
-labels: new analysis
-assignees: ''
-
----
-
 ## Analysis Purpose
 
 <!-- What new analysis issue(s) does your PR address? -->

--- a/.github/PULL_REQUEST_TEMPLATE/other-pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other-pr.md
@@ -1,10 +1,3 @@
----
-name: Other issue
-about: Use this PR template to describe PR with an analysis or documentation (that is not a new example analysis)
-assignees: ''
-
----
-
 ### Purpose
 
 <!-- What was the background and context that lead to this problem? -->

--- a/.github/PULL_REQUEST_TEMPLATE/publish-pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/publish-pr.md
@@ -1,12 +1,3 @@
----
-name: Publish PR
-about: Use this PR template for moving changes from staging -> master
-title: 'Publish'
-labels: publish
-assignees: ''
-
----
-
 ## Changes Being Published
 
 <!-- What overall changes are being included in this "Publish" PR and are they all ready to be published? -->


### PR DESCRIPTION
## Background
An attempt for closing #336 that I *think* should work but I'm not sure. 

Apparently Github doesn't have the same kind of interface for choosing between PR templates as it does for issue templates: https://github.community/t/multiple-pull-request-templates/1850/8 (GitLab does apparently but that's not helpful for us). 

Here's an article (like many others) that explains that Github doesn't have an interface for this but GitLab does: https://seesparkbox.com/foundry/better_pull_requests_merge_requests_with_templates

## About the problem: 

You can use multiple PR templates but it involves piecing together the URL with a `expand=1&template=<TEMPLATE_FILENAME>` type of deal, but this is inconvenient and annoying which is not what templates are supposed to be about. 

Try out this link to see what I mean: https://github.com/AlexsLemonade/refinebio-examples/compare/?expand=1&template=hotfix-pr.md
The templates are here, but there's no easy way to get to them. 

## Potential solution here: 
But, my idea is if Github takes a "main PR template" still, then I can just have links to the others and we can have a not exactly pretty, but somewhat functional way to choose a template. 

I think if we use `<a href="?expand=1&template=hotfix-pr.md"> Hotfix PR </a>` it *should* append to what ever your current URL is? Which maybe is what we want???? 