### PR TITLE
Add timeframe reminder to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -8,13 +8,13 @@ assignees: ''
 ### Background
 
 <!-- What was the background and context that lead to this problem? -->
-<!-- Links to github comments or related issues are also helpful --> 
+<!-- Links to github comments or related issues are also helpful -->
 
 ### Problem
 
 <!-- Why does the current state of things not work?-->
 
-#### What potential "gotchas" do we know of?
+### What potential "gotchas" do we know of?
 
 <!-- Are there any potentially tricky things or unknowns that the person who takes on this issue should know? -->
 
@@ -23,4 +23,11 @@ assignees: ''
 <!-- If applicable, what steps would you need to take to get started? -->
 
 <!-- What other info is needed to complete this task (in however long an interval after the issue is written) -->
+
 <!-- Do you have helpful references and resources we should consult? -->
+
+### Is there a particular timeframe for this issue?
+
+<!-- Is there a particular timeframe that a strategy decision should be made about this issue? --> 
+
+<!-- Is there a particular timeframe that this issue should be acted upon? -->


### PR DESCRIPTION
### Purpose

Communicating timeframes (when relevant) is helpful and important. I added a reminder bit in our issue template so we can better remember to communicate timeframes when they apply. 

### Issue addressed

Related to the kind of comment here: https://github.com/AlexsLemonade/refinebio-examples/issues/340#issuecomment-718815055

## Remaining concerns and questions

If we don't find this reminder is helpful,  then we can remove it later!
