### PR TITLE
Link citations in render

### DIFF
--- a/components/references.bib
+++ b/components/references.bib
@@ -274,7 +274,7 @@ labeling},
 }
 
 @article{Hanzelmann2013,
-  author  = {Sonja H"{a}nzelmann and Robert Castelo and Justin Guinney},
+  author  = {Sonja H{\"a}nzelmann and Robert Castelo and Justin Guinney},
   title   = {Biases in {Illumina} transcriptome sequencing caused by random hexamer priming},
   journal = {BMC Bioinformatics},
   year    = {2013},
@@ -292,7 +292,7 @@ labeling},
   volume = {14},
   number = {1},
   pages = {7},
-  author = {Sonja H\"{a}nzelmann and Robert Castelo and Justin Guinney},
+  author = {Sonja H{\"a}nzelmann and Robert Castelo and Justin Guinney},
   title = {{GSVA}: gene set variation analysis for microarray and {RNA}-Seq data},
   journal = {{BMC} Bioinformatics}
 }
@@ -306,7 +306,7 @@ labeling},
 
 @manual{Hanzelmann-gsva-vignette,
     title = {GSVA: The Gene Set Variation Analysis package for microarray and RNA-seq data},
-    author = {Sonja Hanzelmann and Robert Castelo and Justin Guinney},
+    author = {Sonja H{\"a}nzelmann and Robert Castelo and Justin Guinney},
     year = {2020},
     url = {https://www.bioconductor.org/packages/release/bioc/vignettes/GSVA/inst/doc/GSVA.pdf},
 }

--- a/scripts/render-notebooks.R
+++ b/scripts/render-notebooks.R
@@ -68,7 +68,10 @@ if (!file.exists(opt$rmd)) {
 if (!file.exists(opt$bib_file)) {
   stop("File specified for --bib_file option is not at the specified file path.")
 } else {
-  header_line <- paste("bibliography:", normalizePath(opt$bib_file))
+  header_line <- paste0(
+    "bibliography: ", normalizePath(opt$bib_file), "\n",
+    "link-citations: TRUE"
+  )
 }
 # Check for a citation style
 if (!is.null(opt$cite_style)){


### PR DESCRIPTION
This PR adds a very small change to the render script so that citations get hyperlinks to their positions in the bibliography. 

Separately, it also fixes citations for Sonja Hänzelmann so the umlaut is correctly rendered.

I didn't rerender anything, to keep the changes more modular, but I did check that it works...