### PR TITLE
Try different strategy for ortholog file download

### DIFF
--- a/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
+++ b/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
@@ -192,7 +192,7 @@ zebrafish_hgnc_file <- file.path(
 )
 ```
 
-Using the file path we just declared, we can use the `destfile` argument to download the file to this directory and use this file name. 
+Using the file path we just declared, we can use the `destfile` argument to download the file we need to this directory and use this file name. 
 
 We are downloading this orthology predictions file from the [HGNC database](https://www.genenames.org/).
 If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for.

--- a/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
+++ b/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
@@ -198,7 +198,7 @@ Using the file path we just declared, we can use the `destfile` argument to down
 download.file(
   paste0(
     "ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/",
-    # Can replace with the file name of the species conversion you are looking for
+    # Replace with the file name of the species conversion you are looking for
     "human_zebrafish_hcop_fifteen_column.txt.gz"
   ),
   # The file will be saved to this location and with this name
@@ -206,8 +206,8 @@ download.file(
 )
 ```
 
-If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for
-If you are using Safari as your web browser see the directory using [this link](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/).
+If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for.
+**If you are using Safari** as your web browser see the directory using [this link](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/).
 This is where the files that reflect the data provided via the [HGNC database](https://www.genenames.org/) are maintained.
 If you are using a different dataset, in the last chunk you can replace `zebrafish` in `human_zebrafish_hcop_fifteen_column.txt.gz` with the name of the species you have data for (if you see it listed in the directory).
 

--- a/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
+++ b/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
@@ -122,13 +122,13 @@ This is handy to do because if we want to switch the dataset (see next section f
 
 ```{r}
 # Define the file path to the data directory
-data_dir <- file.path("data", "GSE13490") # Replace with accession number which will be the name of the folder the files will be in
+data_dir <- file.path("data", "GSE71270") # Replace with accession number which will be the name of the folder the files will be in
 
 # Declare the file path to the gene expression matrix file using the data directory saved as `data_dir`
-data_file <- file.path(data_dir, "GSE13490.tsv") # Replace with file path to your dataset
+data_file <- file.path(data_dir, "GSE71270.tsv") # Replace with file path to your dataset
 
 # Declare the file path to the metadata file using the data directory saved as `data_dir`
-metadata_file <- file.path(data_dir, "metadata_GSE13490.tsv") # Replace with file path to your metadata
+metadata_file <- file.path(data_dir, "metadata_GSE71270.tsv") # Replace with file path to your metadata
 ```
 
 Now that our file paths are declared, we can use the `file.exists()` function to check that the files are where we specified above. 
@@ -178,36 +178,49 @@ The [HGNC Comparison of Orthology Predictions (HCOP)](https://www.genenames.org/
 In general, an orthology prediction where most of the databases concur would be considered the reliable, and we will use this to prioritize mapping in cases where there is more than one possible ortholog for a gene.
 HCOP was originally designed to show orthology predictions between human and mouse, but has been expanded to include data from 18 genomes, including zebrafish, which we will use in this notebook [@hcop-help].
 
-First, we need to download the file from the server holding the HGNC data.
-Go to this [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/).
+We can automatically download the human zebrafish file we need for this example using `download.file()` command. 
+For this notebook, we want to download the file named `human_zebrafish_hcop_fifteen_column.txt.gz`.
 
-This is where the files that reflect the data provided via the [HGNC database](https://www.genenames.org/) are maintained.
-Ortholog species files with the '6 Column' output returns the raw assertions, Ensembl gene IDs and Entrez Gene IDs for human and one other species, while the '15 Column' output includes additional information such as the chromosomal location, accession numbers and the databases that support the assertions.
-
-*Note:* If you are using Safari (or the above FTP server link does not open in a web browser), you may need to go to the [link for the HCOP search tool](https://www.genenames.org/tools/hcop/) and scroll down to "Bulk Downloads" to choose a file to download.
-Here, you can find the same files you would find at the server linked above.
-
-To download a file, click the file name.
-For this notebook, you will want to download the file named `human_zebrafish_hcop_fifteen_column.txt.gz`.
-If you are using a different dataset, you can replace `zebrafish` in `human_zebrafish_hcop_fifteen_column.txt.gz` with the name of the species you have data for, and click on that file to download.
-
-<img src="https://github.com/AlexsLemonade/refinebio-examples/raw/07499927a22ed7aa045245e40d692f8e49d7ba52/template/screenshots/download-hgnc-zebrafish-file.png" width=400>
-
-Next, move the `human_zebrafish_hcop_fifteen_column.txt.gz` file into your `data/` folder.
-
-*Note:* If you are using Safari, this file will automatically be decompressed, so the name of the file would instead be `human_zebrafish_hcop_fifteen_column.txt` (don't forget to change the file name in the chunk below if this is the case).
-
-Now let's double check that the file is in the right place.
+First we'll declare a sensible file path for this. 
 
 ```{r}
-# Define the file path to organism orthology file downloaded from the HGNC database
-zebrafish_hgnc_file <- file.path("data", "human_zebrafish_hcop_fifteen_column.txt.gz")
+# Declare what we want this file to be called once we download it
+zebrafish_hgnc_file <- file.path(
+  data_dir,
+  # Can change what the file will be called locally
+  "human_zebrafish_hcop_fifteen_column.txt.gz"
+)
+```
 
+Using the file path we just declared, we can use the `destfile` argument to download the file to this directory and use this file name. 
+
+```{r}
+download.file(
+  paste0(
+    "ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/",
+    # Can replace with the file name of the species conversion you are looking for
+    "human_zebrafish_hcop_fifteen_column.txt.gz"
+  ),
+  # The file will be saved to this location and with this name
+  destfile = zebrafish_hgnc_file
+)
+```
+
+If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for
+If you are using Safari as your web browser see the directory using [this link](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/).
+This is where the files that reflect the data provided via the [HGNC database](https://www.genenames.org/) are maintained.
+If you are using a different dataset, in the last chunk you can replace `zebrafish` in `human_zebrafish_hcop_fifteen_column.txt.gz` with the name of the species you have data for (if you see it listed in the directory).
+
+Ortholog species files with the '6 Column' output returns the raw assertions, Ensembl gene IDs and Entrez Gene IDs for human and one other species, while the '15 Column' output includes additional information such as the chromosomal location, accession numbers and the databases that support the assertions.
+
+Now let's double check that the zebrafish ortholog file is in the right place.
+
+```{r}
 # Check if the organism orthology file file is in the `data` directory
 file.exists(zebrafish_hgnc_file)
 ```
 
-In the next chunk, we will read in the orthology file that was just downloaded.
+Now we can read in the orthology file that we downloaded.
 
 ```{r}
 # Read in the data from HGNC

--- a/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
+++ b/02-microarray/ortholog-mapping_microarray_01_ensembl.Rmd
@@ -194,6 +194,9 @@ zebrafish_hgnc_file <- file.path(
 
 Using the file path we just declared, we can use the `destfile` argument to download the file to this directory and use this file name. 
 
+We are downloading this orthology predictions file from the [HGNC database](https://www.genenames.org/).
+If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for.
+
 ```{r}
 download.file(
   paste0(
@@ -206,9 +209,6 @@ download.file(
 )
 ```
 
-If you are looking for a different species, see the [directory page of the HGNC Comparison of Orthology Predictions (HCOP) files](ftp://ftp.ebi.ac.uk/pub/databases/genenames/hcop/) and find the file name of the species you are looking for.
-**If you are using Safari** as your web browser see the directory using [this link](http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/).
-This is where the files that reflect the data provided via the [HGNC database](https://www.genenames.org/) are maintained.
 If you are using a different dataset, in the last chunk you can replace `zebrafish` in `human_zebrafish_hcop_fifteen_column.txt.gz` with the name of the species you have data for (if you see it listed in the directory).
 
 Ortholog species files with the '6 Column' output returns the raw assertions, Ensembl gene IDs and Entrez Gene IDs for human and one other species, while the '15 Column' output includes additional information such as the chromosomal location, accession numbers and the databases that support the assertions.


### PR DESCRIPTION
### Purpose

I read #299 and gathered the main problems with the ortholog file download were all the Safari caveats:

>To summarize, the general aspects to think about here are how do we handle getting the data while considering:
> Safari users who cannot access the ftp link
Safari users whose downloaded file will be decompressed instead of compressed (.gz)
Other users for machines that we have not yet tested (like Windows)

### Issue addressed

#299 

### Strategy

1) I made this download by `download.file()` which should work no matter the browser someone may be using.
2) I found a thing on Apple that says that if you want to view ftp using Safari, you can change it to an http. So for looking at the files available, I steer the user to that file page but a different link (with http) if they are using Safari. 
3) I trimmed out the GUI instructions since I think this should work no matter what. (I wasn't able to get the GUI to work for me for some reason anyway -- the files won't download). 

I tried think link on Safari and it works. 

Additionally the data file got changed to the wrong dataset that was mouse? This got messed up when I did #298 apparently. It still was running like that but not really, everything was returning 0 rows and no errors. I changed it back to the correct zebrafish so it was actually working. (This is a tad scary and when we are taking a look at polishing the other dataset examples, we should make sure nothing else like this slipped through) 

## Remaining concerns and questions

Do we feel like this is less confusing to follow and more flexible for people who might be using different web browsers? 