### PR TITLE
Add a template for user reports or questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-analysis.md
+++ b/.github/ISSUE_TEMPLATE/new-analysis.md
@@ -2,7 +2,7 @@
 name: New analysis example
 about: Use this issue template for filing a new analysis issue
 title: 'New Analysis Example:'
-labels: new analysis example
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-analysis.md
+++ b/.github/ISSUE_TEMPLATE/new-analysis.md
@@ -2,7 +2,7 @@
 name: New analysis example
 about: Use this issue template for filing a new analysis issue
 title: 'New Analysis Example:'
-labels: ''
+labels: new analysis example
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,6 +1,9 @@
 ---
 name: Other issue
-about: Use this issue template to describe a current issue with an analysis or documentation (that is not a new example analysis)
+about: Use this issue template to describe a current issue with an analysis or documentation
+  (that is not a new example analysis)
+title: ''
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/report-a-problem-or-ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/report-a-problem-or-ask-a-question.md
@@ -1,0 +1,18 @@
+---
+name: Report a problem or ask a question
+about: Use this template to report a problem or ask a question about our examples.
+title: 'User issue:  '
+labels: user report or question
+assignees: ''
+
+---
+
+<!--Hi there, thanks for filing! Please fill out this template to help us respond to your issue.-->
+
+### Which example or page does this problem or question pertain to?
+
+<!--Include a link to the page or use the name-->
+
+### Report the problem you encountered or ask a question
+
+<!--The more detailed information you include, the better we can help!-->


### PR DESCRIPTION
I am working on https://github.com/AlexsLemonade/refinebio-docs/issues/138 and I wanted to include a link to file an issue on GitHub as the preferred way to report a problem or ask a question. Now that we have different issue templates for our own usage, I thought it made sense to create one specifically for _users_ of refine.bio examples rather than those of us who do development!