### PR TITLE
449 - add github action to check frontend urls

### DIFF
--- a/.github/workflows/check-frontend-urls.yml
+++ b/.github/workflows/check-frontend-urls.yml
@@ -1,0 +1,37 @@
+name: Check Refinebio Frontend Urls
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "style and check"
+  check-frontend-urls:
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:4.0.2
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: Rscript -e "install.packages(c('optparse', 'jsonlite'))"
+
+      - name: Run Script to check URLs
+        id: get_missing_urls
+        run: |
+          links=https://raw.githubusercontent.com/AlexsLemonade/refinebio-frontend/blob/master/src/common/examples-links.json
+          results=$(Rscript "scripts/check-frontend-urls.R" --links $links)
+          echo "::set-output name=missing_urls::$results"
+
+      # Fail if any number besides 0 is returned
+      - name: Check if any URLs were missing
+        if: ${{ steps.get_missing_urls.outputs.missing_urls != 'OK' }}
+        run: |
+          echo "Please verify that the following file(s) exist:"
+          echo ${{ steps.get_missing_urls.outputs.missing_urls }}
+          exit 1

--- a/.github/workflows/check-frontend-urls.yml
+++ b/.github/workflows/check-frontend-urls.yml
@@ -8,7 +8,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "style and check"
+  # This workflow contains a single job called "check-frontend-urls"
   check-frontend-urls:
     runs-on: ubuntu-latest
     container:

--- a/scripts/check-frontend-urls.R
+++ b/scripts/check-frontend-urls.R
@@ -1,0 +1,68 @@
+#!/usr/bin/env Rscript
+#
+# Check Refinebio-Frontend urls and return anything missing that was expected or NULL
+
+library(optparse)
+library(jsonlite)
+
+option_list <- list(
+  make_option(
+    opt_str = c("-l", "--links"), type = "character",
+    default = NULL,
+    help = "JSON array that will be interpreted as the expected urls.",
+    metavar = ".json"
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+expected_urls <- fromJSON(txt=opt$links)
+
+# urls -> relatative file paths
+expected_files <- sapply(strsplit(expected_urls, '/refinebio-examples/'), '[', 2)
+
+expected_id_paths <- expected_files[grepl('#', expected_files)]
+
+# remove expected ids from expected_files
+expected_files <- expected_files[!expected_files %in% expected_id_paths]
+# add back the file part of expected_id_paths to test
+expected_files <- c(expected_files, sapply(strsplit(expected_id_paths, "#"), "[", 1))
+
+# get a list of all html files in the project
+existing_files <- list.files(pattern = 'html$', recursive = TRUE)
+
+# get anything thats not in the project
+missing_files <- expected_files[!expected_files %in% existing_files]
+
+# check for missing ids after we know the file isnt missing
+# if a file and id is missing it will first complain that the file is missing
+expected_id_paths <- expected_id_paths[!grepl(paste(missing_files, collapse="|"), expected_id_paths)]
+# find missing ids
+missing_ids = c()
+
+for (expected_id_path in expected_id_paths) {
+  expected_id_parts <- strsplit(expected_id_path, "#")
+  expected_file <- expected_id_parts[[1]][1]
+  expected_id <- expected_id_parts[[1]][2]
+  expected_id_lines <- readr::read_lines(expected_file)
+
+  # check if the id="{expected_id}" exists
+  found_index <- which(grepl(paste0("id=\"", expected_id, "\""), expected_id_lines))
+
+  # add it to missing if not found
+  if (identical(found_index, integer(0))) {
+    missing_ids <- append(missing_ids, expected_id_path)
+  }
+}
+
+
+# group the missing things
+missing <- c(missing_files, missing_ids)
+
+# exit with the list or "OK" if nothing missing
+if(length(missing) == 0) {
+  cat('OK')
+} else {
+  cat(paste0(missing, collapse="\n"))
+}

--- a/scripts/check-frontend-urls.R
+++ b/scripts/check-frontend-urls.R
@@ -20,14 +20,10 @@ opt <- parse_args(OptionParser(option_list = option_list))
 expected_urls <- fromJSON(txt=opt$links)
 
 # urls -> relatative file paths
-expected_files <- sapply(strsplit(expected_urls, '/refinebio-examples/'), '[', 2)
-
-expected_id_paths <- expected_files[grepl('#', expected_files)]
-
-# remove expected ids from expected_files
-expected_files <- expected_files[!expected_files %in% expected_id_paths]
-# add back the file part of expected_id_paths to test
-expected_files <- c(expected_files, sapply(strsplit(expected_id_paths, "#"), "[", 1))
+expected_files <- stringr::word(expected_urls, 2, sep = '/refinebio-examples/')
+expected_id_paths <- stringr::str_subset(expected_files, '#')
+# remove anchors
+expected_files <- stringr::word(expected_files, 1, sep = '#')
 
 # get a list of all html files in the project
 existing_files <- list.files(pattern = 'html$', recursive = TRUE)

--- a/scripts/check-frontend-urls.R
+++ b/scripts/check-frontend-urls.R
@@ -37,10 +37,10 @@ expected_id_paths <- expected_id_paths[!grepl(paste(missing_files, collapse="|")
 # find missing ids
 missing_ids = c()
 
-for (expected_id_path in expected_id_paths) {
-  expected_id_parts <- strsplit(expected_id_path, "#")
-  expected_file <- expected_id_parts[[1]][1]
-  expected_id <- expected_id_parts[[1]][2]
+expected_id_parts_list <- strsplit(expected_id_paths, "#")
+for (expected_id_parts in expected_id_parts_list) {
+  expected_file <- expected_id_parts[1]
+  expected_id <- expected_id_parts[2]
   expected_id_lines <- readr::read_lines(expected_file)
 
   # check if the id="{expected_id}" exists

--- a/scripts/check-frontend-urls.R
+++ b/scripts/check-frontend-urls.R
@@ -44,10 +44,10 @@ for (expected_id_parts in expected_id_parts_list) {
   expected_id_lines <- readr::read_lines(expected_file)
 
   # check if the id="{expected_id}" exists
-  found_index <- which(grepl(paste0("id=\"", expected_id, "\""), expected_id_lines))
+  found <- any(stringr:str_detect(paste0('id="', expected_id, '"'), expected_id_lines))
 
   # add it to missing if not found
-  if (identical(found_index, integer(0))) {
+  if (!found) {
     missing_ids <- append(missing_ids, expected_id_path)
   }
 }


### PR DESCRIPTION
### Purpose

* adds an Rscript that takes a single argument ( destination of a json file that lists urls ) and checks if the files and section id exists
* adds a github action that calls the above script on PR's merging into the `master` branch with a url pointing to refinebio-frontend production list of refinebio-examples' urls

For any subsequent PRs, their checks will fail and present a list of the missing files and ids that correspond to any would be broken link. In order to pass you can request changes on the refinebio-frontend and rerun the `Check Refinebio Frontend Urls` action after the updates are deployed to get a passing result.

### Issue addressed

#449 

#### Gotchas the reviewer should know about

The order of PRs that should be merged would be
* https://github.com/AlexsLemonade/refinebio-examples/pull/457
* https://github.com/AlexsLemonade/refinebio-frontend/pull/945
* this PR

## Remaining concerns and questions

I think logistically an improvement would be for the action to run both on `master` and `staging` prs to match against refinebio-frontend `master` or `dev` branch so staging so they could both be deployed at the same time.
