### PR TITLE
Bump R base version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.0.2
+FROM rocker/tidyverse:4.0.5
 LABEL maintainer="ccdl@alexslemonade.org"
 WORKDIR /rocker-build/
 

--- a/scripts/render-notebooks.R
+++ b/scripts/render-notebooks.R
@@ -144,6 +144,9 @@ google_analytics_file <- normalizePath(file.path("components", "google-analytics
 # Declare path to footer
 footer_file <- normalizePath(file.path("components", "footer.html"))
 
+# Declare path to css
+css_file <- normalizePath(file.path("components", "styles.css"))
+
 # Render the modified notebook
 rmarkdown::render(tmp_file,
   output_format = rmarkdown::html_document(
@@ -151,7 +154,7 @@ rmarkdown::render(tmp_file,
     toc_float = TRUE, number_sections = TRUE,
     highlight = "haddock",
     df_print = "paged",
-    css = normalizePath(file.path("components", "styles.css")),
+    css = css_file,
     includes = rmarkdown::includes(in_header = google_analytics_file,
                                    after_body = footer_file)
   ),


### PR DESCRIPTION
To solve the perennial `matrixStats`/`MatrixGenerics` version incompatibility problem I am bumping the rocker/tidyverse  base image version to R 4.0.5.

This seemed to result in a rendering problem, which my guess was because there was a change in when the css file argument for `rmarkdown::render` is evaluated. To alleviate that I define the full path outside the function call now, and things seem to render fine. At least that is the case locally. We will know for sure after this is merged, I guess.