### PR TITLE
Fix AWS download errors

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,10 +1,8 @@
 name: Build, Render, and Push
 
-# Controls when the action will run. Triggers the workflow on push
-# events only for the master branch
 on:
   push:
-    branches: [ staging, master ]
+    branches: [ staging, master, jashapiro/test-build ]
 
 jobs:
   # This workflow contains a single job called "build-all"
@@ -65,10 +63,12 @@ jobs:
         run: | 
           docker tag ccdl/refinebio-examples:latest ccdl/refinebio-examples:release
           docker push ccdl/refinebio-examples:release
-      
-      # download data
+
       - name: Download data
         run: bash scripts/download-data.sh
+        env:
+          AWS_EC2_METADATA_DISABLED: true
+
       - name: Render all pages to html
         run: |
           docker run \

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -2,7 +2,7 @@ name: Build, Render, and Push
 
 on:
   push:
-    branches: [ staging, master, jashapiro/test-build ]
+    branches: [ staging, master ]
 
 jobs:
   # This workflow contains a single job called "build-all"

--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -16,7 +16,6 @@ FOLDERS=(02-microarray 03-rnaseq 04-advanced-topics)
 # Download by each folder
 for FOLDER in "${FOLDERS[@]}"
   do
-  mkdir -p ../$FOLDER/data/
   # Copy over folders and their contents and put them in the respective section/data folder
-  aws --no-sign-request s3 sync s3://refinebio-examples/$FOLDER/data ../$FOLDER/data/
+  aws --no-sign-request s3 cp s3://refinebio-examples/$FOLDER/data/ ../$FOLDER/data/ --recursive
   done


### PR DESCRIPTION
Fixes problems with AWS downloads: tested the changes and they seem to work. 

From @davidmejia's [earlier PR](https://github.com/AlexsLemonade/refinebio-examples/pull/462): 

Apparently github and aws are having trouble communicating and setting the env var `AWS_EC2_METADATA_DISABLED` to true will remedy this.

Context:

- https://github.com/aws/aws-cli/issues/5623
- https://notestoself.dev/posts/github-action-s3-botocore-awsrequest-process-255-error/