### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.1.0
+authors:
+  - family-names: Savonen
+    given-names: Candace L.
+    orcid: https://orcid.org/0000-0001-6331-7070
+  - family-names: Shapiro
+    given-names: Joshua A.
+    orcid: https://orcid.org/0000-0002-6224-0347
+  - family-names: Bethell
+    given-names: Chante J.
+    orcid: https://orcid.org/0000-0001-9653-8128
+  - family-names: Mejia
+    given-names: David S.
+    orcid: https://orcid.org/0000-0003-1679-0353
+  - family-names: Venkatesh Prasad
+    given-names: Deepashree
+    orcid: https://orcid.org/0000-0001-5756-4083
+  - family-names: Taroni
+    given-names: Jaclyn N.
+    orcid: https://orcid.org/0000-0003-4734-4508
+title: "refine.bio examples"
+version: v2.0
+date-released: 2021-08-03


### PR DESCRIPTION
Closes #470 - here I'm adding `CITATION.cff` where I use the order of: https://github.com/AlexsLemonade/refinebio-examples/graphs/contributors

With the exception that I am last (similar to what we did in: https://github.com/AlexsLemonade/training-modules/pull/498)
