### PR TITLE
Update links to section intros

### DIFF
--- a/01-getting-started/getting-started.Rmd
+++ b/01-getting-started/getting-started.Rmd
@@ -19,7 +19,7 @@ output:
 - [How to use R Markdown Documents](#how-to-use-r-markdown-documents)
 - [An important note about file paths and `.Rmd`s](#an-important-note-about-file-paths-and-rmds)
 - [Resources for learning R](#resources-for-learning-r)
-- [Additional resources from the CCDL:](#additional-resources-from-the-ccdl)
+- [Additional resources from the CCDL](#additional-resources-from-the-ccdl)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -32,7 +32,7 @@ This tutorial has follow-along examples for use with refine.bio downloads.
 ## About how this tutorial book is structured 
 
 This tutorial contains follow-along analysis examples for refine.bio gene expression data.
-The analysis examples are organized by technology: ["microarray"](https://alexslemonade.github.io/refinebio-examples/02-microarray/intro-to-microarray.html) or ["RNA-seq"](https://alexslemonade.github.io/refinebio-examples/03-rna-seq/intro-to-rna-seq.html), in addition to an ["Advanced Topics"](https://alexslemonade.github.io/refinebio-examples/04-advanced-topics/intro-to-advanced-topics.html) section.
+The analysis examples are organized by technology: ["Microarray"](https://alexslemonade.github.io/refinebio-examples/02-microarray/00-intro-to-microarray.html) or ["RNA-seq"](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/00-intro-to-rnaseq.html), in addition to an ["Advanced Topics"](https://alexslemonade.github.io/refinebio-examples/04-advanced-topics/00-intro-to-advanced-topics.html) section.
 Each analysis is self-contained and provides information with how to obtain the dataset used in the example from refine.bio.
 We encourage you to download the [`.Rmd`](http://rmarkdown.rstudio.com) and follow the "getting started" section in the example before diving into our analysis examples.
 


### PR DESCRIPTION
While testing #473 for merging to master, I found a couple of other broken links on the Getting Started page.

This PR fixes those errors to point to the correct intro pages.