### PR TITLE
Fix WGCNA url

### DIFF
--- a/04-advanced-topics/network-analysis_rnaseq_01_wgcna.Rmd
+++ b/04-advanced-topics/network-analysis_rnaseq_01_wgcna.Rmd
@@ -31,7 +31,7 @@ We recommend taking a look at our [Resources for Learning R](https://alexslemona
 
 ## Obtain the `.Rmd` file
 
-To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/03-rnaseq/differential_expression_rnaseq_01_rnaseq.Rmd).
+To run this example yourself, [download the `.Rmd` for this analysis by clicking this link](https://alexslemonade.github.io/refinebio-examples/04-advanced-topics/network-analysis_rnaseq_01_wgcna.Rmd).
 
 Clicking this link will most likely send this to your downloads folder on your computer. 
 Move this `.Rmd` file to where you would like this example and its files to be stored.


### PR DESCRIPTION
In #474, I fixed a broken link, but it was not the one actually requested by the user... They were asking about the link on the WGCNA page, which was coincidentally (erroneously) the same as the DE page, and pointed to the same broken place. So now it should point to the correct place, and work.