### PR TITLE
Update GHA artifacts version

### DIFF
--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -52,7 +52,7 @@ jobs:
           cat spell_check_results.tsv
 
       - name: Archive spelling errors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spell-check-results
           path: spell_check_results.tsv


### PR DESCRIPTION
Closes #483 

This PR bumps `upload-artifact@v3` -> `upload-artifact@v4`. 
I did have the brief thought that we could swap this over to our spellcheck repo as well, but I decided fairly quickly that that was probably unnecessary for this repo at this time. Let me know if you disagree!